### PR TITLE
Cross group querying and `test` documentation

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -38,7 +38,7 @@ DESC = {
     "EDIT": "Edit a rendering setting",
     "LIST": "List available rendering settings",
     "JPEG": "Render as JPEG",
-    "TEST": "Test that ",
+    "TEST": "Test that underlying pixel data is available",
 }
 
 HELP = """Tools for working with rendering settings
@@ -93,6 +93,13 @@ Examples:
 
     # ...optionally setting parameters
     bin/omero render jpeg --z=4 Image:6 > test.jpg
+
+    # %(TEST)s
+    bin/omero render test Image:7
+    bin/omero render test --skipthumbs Image:7
+    # If underlying pixel data is available don't regenerate thumbnails
+    bin/omero render test --force Image:7
+    # Force creation of pixel data file in binary repository if missing
 
 """ % DESC
 

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -499,6 +499,7 @@ class RenderControl(BaseControl):
     def test(self, args):
         client = self.ctx.conn(args)
         gateway = BlitzGateway(client_obj=client)
+        gateway.SERVICE_OPTS.setOmeroGroup('-1')
         for img in self.render_images(gateway, args.object, batch=1):
             # try:
             self.test_per_pixel(

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -507,8 +507,9 @@ class RenderControl(BaseControl):
             # img._closeRE()
 
     def test_per_pixel(self, client, pixid, force, thumb):
-        fail = {"omero.pixeldata.fail_if_missing": "true"}
-        make = {"omero.pixeldata.fail_if_missing": "false"}
+        ctx = {'omero.group': '-1'}
+        fail = {"omero.pixeldata.fail_if_missing": "true", 'omero.group': '-1'}
+        make = {"omero.pixeldata.fail_if_missing": "false", 'omero.group': '-1'}
 
         start = time.time()
         error = ""
@@ -542,8 +543,8 @@ class RenderControl(BaseControl):
         elif thumb:
             tb = client.sf.createThumbnailStore()
             try:
-                tb.setPixelsId(long(pixid))
-                tb.getThumbnailByLongestSide(rint(96))
+                tb.setPixelsId(long(pixid), ctx)
+                tb.getThumbnailByLongestSide(rint(96), ctx)
             finally:
                 tb.close()
 

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -96,10 +96,8 @@ Examples:
 
     # %(TEST)s
     bin/omero render test Image:7
-    bin/omero render test --skipthumbs Image:7
-    # If underlying pixel data is available don't regenerate thumbnails
+    bin/omero render test --thumb Image:7
     bin/omero render test --force Image:7
-    # Force creation of pixel data file in binary repository if missing
 
 """ % DESC
 
@@ -297,8 +295,15 @@ class RenderControl(BaseControl):
             "channels",
             help="Rendering definition, local file or OriginalFile:ID")
 
-        test.add_argument("--force", action="store_true")
-        test.add_argument("--thumb", action="store_true")
+        test.add_argument(
+            "--force", action="store_true",
+            help="Force creation of pixel data file in binary "
+                 "repository if missing"
+        )
+        test.add_argument(
+            "--thumb", action="store_true",
+            help="If underlying pixel data available test thumbnail retrieval"
+        )
 
     def _lookup(self, gateway, type, oid):
         # TODO: move _lookup to a _configure type

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -509,8 +509,10 @@ class RenderControl(BaseControl):
 
     def test_per_pixel(self, client, pixid, force, thumb):
         ctx = {'omero.group': '-1'}
-        fail = {"omero.pixeldata.fail_if_missing": "true", 'omero.group': '-1'}
-        make = {"omero.pixeldata.fail_if_missing": "false", 'omero.group': '-1'}
+        fail = {"omero.pixeldata.fail_if_missing": "true"}
+        fail.update(ctx)
+        make = {"omero.pixeldata.fail_if_missing": "false"}
+        make.update(ctx)
 
         start = time.time()
         error = ""

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -231,3 +231,15 @@ class TestRender(CLITest):
             self.assert_image_rmodel(img, expected_greyscale)
             # img._closeRE()
         # assert not gw._assert_unregistered("testEditSingleC")
+
+    @pytest.mark.permissions
+    def test_cross_group(self, capsys):
+        img = self.create_image(sizec=1)
+        login = self.root_login_args()
+        # Run test as self and as root
+        self.cli.invoke(self.args+ ["test", self.imageid], strict=True)
+        self.cli.invoke(login + ["render", "test", self.imageid], strict=True)
+        out, err = capsys.readouterr()
+        lines = out.split("\n")
+        assert "ok" in lines[0]
+        assert "ok" in lines[1]


### PR DESCRIPTION
Switches the logic of the `test` command to perform cross group querying. Without this or a similar change you must know the group of the data you want to test before executing the command.

Documentation has also been updated to reflect the impact of the `--skipthumbs` and `--force` command line arguments on the command.

/cc @emilroz 