### PR TITLE
Fix render plugin

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -237,7 +237,7 @@ class RenderControl(BaseControl):
         sub = parser.sub()
         info = parser.add(sub, self.info, DESC["INFO"])
         copy = parser.add(sub, self.copy, DESC["COPY"])
-        set = parser.add(sub, self.set, DESC["SET"])
+        setCmd = parser.add(sub, self.set, DESC["SET"])
         edit = parser.add(sub, self.edit, DESC["EDIT"])
         test = parser.add(sub, self.test, DESC["TEST"])
 
@@ -245,10 +245,10 @@ class RenderControl(BaseControl):
         render_help = ("rendering def source of form <object>:<id>. "
                        "Image is assumed if <object>: is omitted.")
 
-        for x in (info, copy, set, edit, test):
+        for x in (info, copy, setCmd, edit, test):
             x.add_argument("object", type=render_type, help=render_help)
 
-        set.add_argument(
+        setCmd.add_argument(
             "--copy", help="Batch edit images by copying rendering settings",
             action="store_true")
 
@@ -256,7 +256,7 @@ class RenderControl(BaseControl):
             "--copy", help="Batch edit images by copying rendering settings",
             action="store_true")
 
-        for x in (copy, set, edit):
+        for x in (copy, setCmd, edit):
             x.add_argument(
                 "--skipthumbs", help="Don't re-generate thumbnails",
                 action="store_true")
@@ -269,7 +269,7 @@ class RenderControl(BaseControl):
 
         copy.add_argument("target", type=render_type, help=render_help,
                           nargs="+")
-        set.add_argument(
+        setCmd.add_argument(
             "channels",
             help="Rendering definition, local file or OriginalFile:ID")
         edit.add_argument(

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -216,7 +216,7 @@ class RenderObject(object):
 
         self.range = image.getPixelRange()
         self.channels = map(lambda x: ChannelObject(x),
-                            image.getChannels(noRE=True))
+                            image.getChannels(noRE=False))
         self.model = image.isGreyscaleRenderingModel() and \
             'greyscale' or 'color'
         self.projection = image.getProjection()

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -489,6 +489,10 @@ class RenderControl(BaseControl):
                                   args.skipthumbs)
                 break
 
+        if not iids:
+            self.ctx.die(113, "ERROR: No images found for %s %d" %
+                         (args.object.__class__.__name__, args.object.id._val))
+
         if namedict:
             self._update_channel_names(gateway, iids, namedict)
 

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -28,6 +28,8 @@ from omero.gateway import BlitzGateway
 from omero.model import Image
 from omero.model import Plate
 from omero.model import Screen
+from omero.model import Dataset
+from omero.model import Project
 from omero.rtypes import rint
 from omero.util import pydict_text_io
 
@@ -318,6 +320,27 @@ class RenderControl(BaseControl):
                             rv = []
             if rv:
                 yield rv
+
+        elif isinstance(object, Project):
+            prj = self._lookup(gateway, "Project", object.id)
+            for ds in prj.listChildren():
+                for rv in self.render_images(gateway, ds._obj, batch):
+                    yield rv
+
+        elif isinstance(object, Dataset):
+            ds = self._lookup(gateway, "Dataset", object.id)
+            rv = []
+            for img in ds.listChildren():
+                if batch == 1:
+                    yield img
+                else:
+                    rv.append(img)
+                    if len(rv) == batch:
+                        yield rv
+                        rv = []
+            if rv:
+                yield rv
+
         elif isinstance(object, Image):
             img = self._lookup(gateway, "Image", object.id)
             if batch == 1:

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -237,7 +237,7 @@ class RenderControl(BaseControl):
         sub = parser.sub()
         info = parser.add(sub, self.info, DESC["INFO"])
         copy = parser.add(sub, self.copy, DESC["COPY"])
-        setCmd = parser.add(sub, self.set, DESC["SET"])
+        set_cmd = parser.add(sub, self.set, DESC["SET"])
         edit = parser.add(sub, self.edit, DESC["EDIT"])
         test = parser.add(sub, self.test, DESC["TEST"])
 
@@ -245,10 +245,10 @@ class RenderControl(BaseControl):
         render_help = ("rendering def source of form <object>:<id>. "
                        "Image is assumed if <object>: is omitted.")
 
-        for x in (info, copy, setCmd, edit, test):
+        for x in (info, copy, set_cmd, edit, test):
             x.add_argument("object", type=render_type, help=render_help)
 
-        setCmd.add_argument(
+        set_cmd.add_argument(
             "--copy", help="Batch edit images by copying rendering settings",
             action="store_true")
 
@@ -256,7 +256,7 @@ class RenderControl(BaseControl):
             "--copy", help="Batch edit images by copying rendering settings",
             action="store_true")
 
-        for x in (copy, setCmd, edit):
+        for x in (copy, set_cmd, edit):
             x.add_argument(
                 "--skipthumbs", help="Don't re-generate thumbnails",
                 action="store_true")
@@ -269,7 +269,7 @@ class RenderControl(BaseControl):
 
         copy.add_argument("target", type=render_type, help=render_help,
                           nargs="+")
-        setCmd.add_argument(
+        set_cmd.add_argument(
             "channels",
             help="Rendering definition, local file or OriginalFile:ID")
         edit.add_argument(
@@ -469,9 +469,7 @@ class RenderControl(BaseControl):
             self._update_channel_names(gateway, iids, namedict)
 
     def edit(self, args):
-        self.ctx.err("WARNING: 'edit' command is deprecated, please "
-                     "use 'set' instead.")
-        self.set(args)
+        self.ctx.die(112, "ERROR: 'edit' command has been renamed to 'set'")
 
     def test(self, args):
         client = self.ctx.conn(args)

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -33,6 +33,8 @@ from omero.util import pydict_text_io
 
 from omero import UnloadedEntityException
 
+from omero_ext.argparse import SUPPRESS
+
 DESC = {
     "COPY": "Copy rendering setting to multiple objects",
     "INFO": "Show details of a rendering setting",
@@ -267,6 +269,7 @@ class RenderControl(BaseControl):
         info = parser.add(sub, self.info, DESC["INFO"])
         copy = parser.add(sub, self.copy, DESC["COPY"])
         set = parser.add(sub, self.set, DESC["SET"])
+        edit = parser.add(sub, self.edit, help=SUPPRESS)
         test = parser.add(sub, self.test, DESC["TEST"])
         # list = parser.add(sub, self.list, DESC["LIST"])
         # jpeg = parser.add(sub, self.jpeg, DESC["JPEG"])
@@ -278,14 +281,18 @@ class RenderControl(BaseControl):
         render_help = ("rendering def source of form <object>:<id>. "
                        "Image is assumed if <object>: is omitted.")
 
-        for x in (info, copy, set, test):
+        for x in (info, copy, set, edit, test):
             x.add_argument("object", type=render_type, help=render_help)
 
         set.add_argument(
             "--copy", help="Batch edit images by copying rendering settings",
             action="store_true")
 
-        for x in (copy, set):
+        edit.add_argument(
+            "--copy", help="Batch edit images by copying rendering settings",
+            action="store_true")
+
+        for x in (copy, set, edit):
             x.add_argument(
                 "--skipthumbs", help="Don't re-generate thumbnails",
                 action="store_true")
@@ -299,6 +306,9 @@ class RenderControl(BaseControl):
         copy.add_argument("target", type=render_type, help=render_help,
                           nargs="+")
         set.add_argument(
+            "channels",
+            help="Rendering definition, local file or OriginalFile:ID")
+        edit.add_argument(
             "channels",
             help="Rendering definition, local file or OriginalFile:ID")
 
@@ -514,6 +524,10 @@ class RenderControl(BaseControl):
             self._update_channel_names(gateway, iids, namedict)
 
         # gateway._assert_unregistered("edit")
+
+    def edit(self, args):
+        self.ctx.err("Warning: 'edit' command is deprecated (renamed to 'set')")
+        self.set(args)
 
     def test(self, args):
         client = self.ctx.conn(args)

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -31,6 +31,7 @@ from omero.model import Screen
 from omero.rtypes import rint
 from omero.util import pydict_text_io
 
+from omero import UnloadedEntityException
 
 DESC = {
     "COPY": "Copy rendering setting to multiple objects",
@@ -119,10 +120,16 @@ class ChannelObject(object):
         self.emWave = channel.getEmissionWave()
         self.label = channel.getLabel()
         self.color = channel.getColor()
-        self.min = channel.getWindowMin()
-        self.max = channel.getWindowMax()
-        self.start = channel.getWindowStart()
-        self.end = channel.getWindowEnd()
+        try:
+            self.min = channel.getWindowMin()
+            self.max = channel.getWindowMax()
+            self.start = channel.getWindowStart()
+            self.end = channel.getWindowEnd()
+        except UnloadedEntityException:
+            self.min = None
+            self.max = None
+            self.start = None
+            self.end = None
         self.active = channel.isActive()
 
     def init_from_dict(self, d):

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -76,7 +76,7 @@ Examples:
     # for all the remaining images in the collection, using the first image
     # as the source. Note using this flag may have different results from not
     # using it if the images had different settings to begin with and you are
-    # only overridding a subset of the settings (all images will end up with
+    # only overriding a subset of the settings (all images will end up with
     # the same full rendering settings).
 
     bin/omero render set --skipthumbs ...

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -290,6 +290,7 @@ class RenderControl(BaseControl):
 
     def _lookup(self, gateway, type, oid):
         # TODO: move _lookup to a _configure type
+        gateway.SERVICE_OPTS.setOmeroGroup('-1')
         obj = gateway.getObject(type, oid)
         if not obj:
             self.ctx.die(110, "No such %s: %s" % (type, oid))

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -27,6 +27,8 @@ from omero.cli import NonZeroReturnCode
 from cli import CLITest
 from omero.gateway import BlitzGateway
 
+from omero.model import DatasetI, DatasetImageLinkI, ImageI, ProjectI
+
 
 # TODO: rdefid, tbid
 SUPPORTED = {
@@ -34,6 +36,8 @@ SUPPORTED = {
     "imageid": "Image:-1",
     "plateid": "Plate:-1",
     "screenid": "Screen:-1",
+    "projectid": "Project:-1",
+    "datasetid": "Dataset:-1"
 }
 
 
@@ -44,8 +48,24 @@ class TestRender(CLITest):
         self.cli.register("render", RenderControl, "TEST")
         self.args += ["render"]
 
+    def create_project(self, **kwargs):
+        self.project = self.make_project(client=self.client)
+        self.dataset = self.make_dataset(client=self.client)
+        self.projectid = "Project:%s" % self.project.id._val
+        self.datasetid = "Dataset:%s" % self.dataset.id._val
+
+        self.link(obj1=self.project, obj2=self.dataset)
+        target = "Dataset:%s" % self.datasetid
+        images = self.import_fake_file(images_count=0, client=self.client, T=target, **kwargs)
+        for i in images:
+            img = self.gw.getObject("Image", i.id.val)
+            img.getThumbnail(size=(96,), direct=False)
+
     def create_image(self, sizec=4):
         self.gw = BlitzGateway(client_obj=self.client)
+
+        self.create_project(sizec=sizec)
+
         self.plates = []
         for plate in self.import_plates(client=self.client, fields=2,
                                         sizeC=sizec, screens=1):

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -66,9 +66,7 @@ class TestRender(CLITest):
                     img = w.getImage(index=i)
                     img.getThumbnail(
                         size=(96,), direct=False)
-                    # img._closeRE()
-        # self.imgobj._closeRE()
-        # assert not self.gw._assert_unregistered("create_image")
+        assert not self.gw._assert_unregistered("create_image")
 
     def get_target_imageids(self, target):
         if target in (self.idonly, self.imageid):
@@ -194,8 +192,7 @@ class TestRender(CLITest):
             for c in xrange(len(channels)):
                 self.assert_channel_rdef(channels[c], rd['channels'][c + 1])
             self.assert_image_rmodel(img, expected_greyscale)
-            # img._closeRE()
-        # assert not gw._assert_unregistered("testSet")
+        assert not gw._assert_unregistered("testSet")
 
     # Once testSet is no longer broken testSetSingleC could be merged into
     # it with sizec and greyscale parameters

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -169,7 +169,7 @@ class TestRender(CLITest):
     @pytest.mark.xfail(
         reason=('https://trello.com/c/lyyGuRow/'
                 '657-incorrect-logical-channels-in-clitest-importplates'))
-    def test_edit(self, target_name, tmpdir):
+    def test_set(self, target_name, tmpdir):
         sizec = 4
         greyscale = None
         # 4 channels so should default to colour model
@@ -180,7 +180,7 @@ class TestRender(CLITest):
         # Should work with json and yaml, but yaml is an optional dependency
         rdfile.write(json.dumps(rd))
         target = getattr(self, target_name)
-        self.args += ["edit", target, str(rdfile)]
+        self.args += ["set", target, str(rdfile)]
         self.cli.invoke(self.args, strict=True)
 
         iids = self.get_target_imageids(target)
@@ -195,13 +195,13 @@ class TestRender(CLITest):
                 self.assert_channel_rdef(channels[c], rd['channels'][c + 1])
             self.assert_image_rmodel(img, expected_greyscale)
             # img._closeRE()
-        # assert not gw._assert_unregistered("testEdit")
+        # assert not gw._assert_unregistered("testSet")
 
-    # Once testEdit is no longer broken testEditSingleC could be merged into
+    # Once testSet is no longer broken testSetSingleC could be merged into
     # it with sizec and greyscale parameters
     @pytest.mark.parametrize('target_name', sorted(SUPPORTED.keys()))
     @pytest.mark.parametrize('greyscale', [None, True, False])
-    def test_edit_single_channel(self, target_name, greyscale, tmpdir):
+    def test_set_single_channel(self, target_name, greyscale, tmpdir):
         sizec = 1
         # 1 channel so should default to greyscale model
         expected_greyscale = ((greyscale is None) or greyscale)
@@ -211,7 +211,7 @@ class TestRender(CLITest):
         # Should work with json and yaml, but yaml is an optional dependency
         rdfile.write(json.dumps(rd))
         target = getattr(self, target_name)
-        self.args += ["edit", target, str(rdfile)]
+        self.args += ["set", target, str(rdfile)]
         self.cli.invoke(self.args, strict=True)
 
         iids = self.get_target_imageids(target)

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -60,6 +60,7 @@ class TestRender(CLITest):
         for i in images:
             img = self.gw.getObject("Image", i.id.val)
             img.getThumbnail(size=(96,), direct=False)
+        assert not self.gw._assert_unregistered("create_project")
 
     def create_image(self, sizec=4):
         self.gw = BlitzGateway(client_obj=self.client)
@@ -101,6 +102,17 @@ class TestRender(CLITest):
             for s in self.plates:
                 for w in self.plates[0].listChildren():
                     imgs.extend([w.getImage(0).id, w.getImage(1).id])
+            return imgs
+        if target == self.datasetid:
+            imgs = []
+            for img in self.dataset.listChildren():
+                imgs.append(img.id)
+            return imgs
+        if target == self.projectid:
+            imgs = []
+            for d in self.project.listChildren():
+                for img in d.listChildren():
+                    imgs.append(img.id)
             return imgs
         raise Exception('Unknown target: %s' % target)
 
@@ -202,7 +214,6 @@ class TestRender(CLITest):
         self.cli.invoke(self.args, strict=True)
 
         iids = self.get_target_imageids(target)
-        print 'Got %d images' % len(iids)
         gw = BlitzGateway(client_obj=self.client)
         for iid in iids:
             # Get the updated object
@@ -232,7 +243,6 @@ class TestRender(CLITest):
         self.cli.invoke(self.args, strict=True)
 
         iids = self.get_target_imageids(target)
-        print 'Got %d images' % len(iids)
         gw = BlitzGateway(client_obj=self.client)
         for iid in iids:
             # Get the updated object

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -77,7 +77,8 @@ class TestRender(CLITest):
         self.projectid = "Project:%s" % self.project.id
         self.datasetid = "Dataset:%s" % self.dataset.id
         self.link(obj1=project, obj2=dataset)
-        images = self.import_fake_file(images_count=1, sizeC=sizec, client=self.client)
+        images = self.import_fake_file(images_count=1, sizeC=sizec,
+                                       client=self.client)
         self.link(obj1=dataset, obj2=images[0])
         img = self.gw.getObject("Image", images[0].id.val)
         img.getThumbnail(size=(96,), direct=False)
@@ -255,10 +256,10 @@ class TestRender(CLITest):
 
     @pytest.mark.permissions
     def test_cross_group(self, capsys):
-        img = self.create_image(sizec=1)
+        self.create_image(sizec=1)
         login = self.root_login_args()
         # Run test as self and as root
-        self.cli.invoke(self.args+ ["test", self.imageid], strict=True)
+        self.cli.invoke(self.args + ["test", self.imageid], strict=True)
         self.cli.invoke(login + ["render", "test", self.imageid], strict=True)
         out, err = capsys.readouterr()
         lines = out.split("\n")


### PR DESCRIPTION
Replaces #3 (closed), rebased to latest `master` branch.

- Bugfix for the `info` command
- Rename `edit` command to `set`
- Enable setting rendering settings also on Project and Dataset level.

Test:
- Check that the `info` command works
- Check that previously called`edit` command is now called `set` and it still works (calling `edit` should provide a reasonable error message about the renaming).
- Try to set rendering settings for a Project and a Dataset and make sure that works.

I think the easiest way to test the plugin is:
- Download the plugin: https://raw.githubusercontent.com/dominikl/omero-cli-render/8d4a8f94ae3f60fec8f15e7a2a0d26c053d1406f/src/omero_cli_render.py
- Put in a directory called `omero/plugins` e. g. `~/test/omero/plugins` 
- Add the parent directory to the PYTHONPATH, e.g. `export PYTHONPATH=$PYTHONPATH:~/test` 
- Then it should be picked up automatically when you run `bin/omero` within the OMERO.server or OMERO.py package.

See:
- Previous discussion on closed PR #3 
- https://github.com/ome/omero-cli-render/issues/5
- https://github.com/ome/omero-cli-render/issues/4
