### PR TITLE
General cleanup

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -39,8 +39,7 @@ HELP = "Tools for working with rendering settings"
 
 INFO_HELP = """Show details of a rendering setting
 
-    Examples: 
-    bin/omero render info RenderingDef:1
+    Examples:
     bin/omero render info Image:123
 """
 
@@ -48,7 +47,6 @@ COPY_HELP = """Copy rendering setting to multiple objects
     Targets can be Image(s), Dataset(s), Project(s), Plate(s) or Screen(s).
 
     Examples:
-    bin/omero render copy RenderingDef:1 Image:123
     bin/omero render copy Image:456 Image:222 Image:333
     bin/omero render copy Image:456 Plate:1
     bin/omero render copy Image:456 Dataset:1

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -466,6 +466,7 @@ class RenderControl(BaseControl):
 
         try:
             greyscale = data['greyscale']
+            print 'greyscale=%s' % data['greyscale']
         except KeyError:
             greyscale = None
 

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -89,6 +89,9 @@ SET_HELP = """Set rendering settings
       ...
       
     # Omitted fields will keep their current values
+    
+    # If a channel is turned off (active: False) other settings like min,
+    # max, etc. will be ignored.
 """
 
 TEST_HELP = """Test that underlying pixel data is available
@@ -468,7 +471,10 @@ class RenderControl(BaseControl):
         for (i, c) in newchannels.iteritems():
             if c.label:
                 namedict[i] = c.label
-            cindices.append(i)
+            if c.active is False:
+                cindices.append(-i)
+            else:
+                cindices.append(i)
             rangelist.append([c.min, c.max])
             colourlist.append(c.color)
 
@@ -481,7 +487,8 @@ class RenderControl(BaseControl):
             # channels which are not specified.
             imgChannels = img.getChannels()
             for c in range(len(imgChannels)):
-                if (c+1) not in cindices and imgChannels[c].isActive():
+                if (c+1) not in cindices and -(c+1) not in cindices\
+                        and imgChannels[c].isActive():
                     cindices.append(c+1)
                     rangelist.append([None, None])
                     colourlist.append(None)

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -403,6 +403,9 @@ class RenderControl(BaseControl):
                 self.ctx.err("Error: Image:%s" % missing)
                 del batch[missing]
 
+            self.ctx.out("Rendering settings successfully copied to %d images."
+                         % len(rv[True]))
+
             if not skipthumbs:
                 self._generate_thumbs(batch.values())
 

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -71,14 +71,6 @@ Examples:
     # Omitted fields will keep their current values, omitted channel-indices
     # will be turned off.
 
-    bin/omero render set --copy Screen:1 <YAML or JSON file>
-    # Equivalent to calling set for a single image followed by calling copy
-    # for all the remaining images in the collection, using the first image
-    # as the source. Note using this flag may have different results from not
-    # using it if the images had different settings to begin with and you are
-    # only overriding a subset of the settings (all images will end up with
-    # the same full rendering settings).
-
     bin/omero render set --skipthumbs ...
     # Update rendering settings but don't regenerate thumbnails.
 
@@ -249,14 +241,6 @@ class RenderControl(BaseControl):
 
         for x in (info, copy, set_cmd, edit, test):
             x.add_argument("object", type=render_type, help=render_help)
-
-        set_cmd.add_argument(
-            "--copy", help="Batch edit images by copying rendering settings",
-            action="store_true")
-
-        edit.add_argument(
-            "--copy", help="Batch edit images by copying rendering settings",
-            action="store_true")
 
         for x in (copy, set_cmd, edit):
             x.add_argument(
@@ -479,15 +463,6 @@ class RenderControl(BaseControl):
                 "Updated rendering settings for Image:%s" % img.id)
             if not args.skipthumbs:
                 self._generate_thumbs([img])
-
-            if args.copy:
-                # Edit first image only, copy to rest
-                # Don't close source image until outer
-                # loop is done.
-                self._copy_single(gateway,
-                                  img, args.object,
-                                  args.skipthumbs)
-                break
 
         if not iids:
             self.ctx.die(113, "ERROR: No images found for %s %d" %

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -88,10 +88,11 @@ SET_HELP = """Set rendering settings
         color: "00FF00"
       ...
       
-    # Omitted fields will keep their current values
-    
-    # If a channel is turned off (active: False) other settings like min,
-    # max, etc. will be ignored.
+    # Omitted fields will keep their current values.
+    # If the file specifies to turn off a channel (active: False) then the
+    # other settings like min, max, and color which might be specified for
+    # that channel in the same file will be ignored, however the channel 
+    # name (label) is still taken into account.
 """
 
 TEST_HELP = """Test that underlying pixel data is available
@@ -257,14 +258,16 @@ class RenderControl(BaseControl):
 
         render_type = ProxyStringType("Image")
         src_help = ("Rendering def source in the form <object>:<id>. "
-                    "Image is assumed if <object>: is omitted.")
+                    "Image is assumed if <object>: is omitted. Object "
+                    "can be Image, Project, Dataset, Plate or Screen")
 
         for x in (info, copy, test):
             x.add_argument("object", type=render_type, help=src_help)
 
         tgt_help = ("Object to apply the rendering settings to in "
                     "the form <object>:<id>. Image is assumed if <object>: "
-                    "is omitted.")
+                    "is omitted. Object can be Image, Project, Dataset, Plate "
+                    "or Screen")
         for x in (set_cmd, edit):
             x.add_argument("object", type=render_type, help=tgt_help,
                            nargs="+")
@@ -284,10 +287,10 @@ class RenderControl(BaseControl):
                           nargs="+")
         set_cmd.add_argument(
             "channels",
-            help="Rendering definition, local file or OriginalFile:ID")
+            help="Rendering settings, local file or OriginalFile:ID")
         edit.add_argument(
             "channels",
-            help="Rendering definition, local file or OriginalFile:ID")
+            help="Rendering settings, local file or OriginalFile:ID")
 
         test.add_argument(
             "--force", action="store_true",

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -287,10 +287,12 @@ class RenderControl(BaseControl):
                           nargs="+")
         set_cmd.add_argument(
             "channels",
-            help="Rendering settings, local file or OriginalFile:ID")
+            help="Local file or OriginalFile:ID which specifies the "
+                 "rendering settings")
         edit.add_argument(
             "channels",
-            help="Rendering settings, local file or OriginalFile:ID")
+            help="Local file or OriginalFile:ID which specifies the "
+                 "rendering settings")
 
         test.add_argument(
             "--force", action="store_true",

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -38,14 +38,24 @@ from omero import UnloadedEntityException
 HELP = "Tools for working with rendering settings"
 
 INFO_HELP = """Show details of a rendering setting
-
+    
+    The syntax for specifying objects is: <object>:<id>
+    <object> can be Image, Project, Dataset, Plate or Screen.
+    Image is assumed if <object>: is omitted
+    
     Examples:
     bin/omero render info Image:123
 """
 
 COPY_HELP = """Copy rendering setting to multiple objects
-    Targets can be Image(s), Dataset(s), Project(s), Plate(s) or Screen(s).
-
+    
+    The syntax for specifying objects is: <object>:<id>
+    <object> can be Image, Project, Dataset, Plate or Screen.
+    Image is assumed if <object>: is omitted
+    
+    The first argument is the source of the rendering settings,
+    the following arguments are the targets.
+    
     Examples:
     bin/omero render copy Image:456 Image:222 Image:333
     bin/omero render copy Image:456 Plate:1
@@ -56,14 +66,17 @@ EDIT_HELP = "Deprecated, please use 'set' instead"
 
 SET_HELP = """Set rendering settings
 
+    The syntax for specifying objects is: <object>:<id>
+    <object> can be Image, Project, Dataset, Plate or Screen.
+    Image is assumed if <object>: is omitted
+    
     Examples:
+    bin/omero render set Image:1 settings.json
+    bin/omero render set Dataset:1 settings.yml
     
-    bin/omero render set Image:1 <YAML or JSON file>
-    bin/omero render set Dataset:1 <YAML or JSON file>
-    
-    # where the input file contains a top-level channels key (required), and
-    # an optional top-level greyscale key (True: greyscale, False: color).
-    # Channel elements are index:dictionaries of the form:
+    # where the input file (YAML or JSON) contains a top-level channels 
+    # key (required), and an optional top-level greyscale key (True: greyscale,
+    # False: color). Channel elements are index:dictionaries of the form:
 
     channels:
       <index>: (Channel-index, int, 1-based)
@@ -96,12 +109,19 @@ SET_HELP = """Set rendering settings
 """
 
 TEST_HELP = """Test that underlying pixel data is available
-
+    
+    The syntax for specifying objects is: <object>:<id>
+    <object> can be Image, Project, Dataset, Plate or Screen.
+    Image is assumed if <object>: is omitted
+    
     Output:
     <Status>: <Pixels ID> <Time (in sec) to load the thumbnail> \
 <Error details, if any>
 
     Where status is either ok, miss, fill, cancel, or fail.
+    
+    Examples:
+    bin/omero render test Image:1 
 """
 
 
@@ -257,17 +277,12 @@ class RenderControl(BaseControl):
         test = parser.add(sub, self.test, TEST_HELP)
 
         render_type = ProxyStringType("Image")
-        src_help = ("Rendering def source in the form <object>:<id>. "
-                    "Image is assumed if <object>: is omitted. Object "
-                    "can be Image, Project, Dataset, Plate or Screen")
+        src_help = ("Rendering settings source")
 
         for x in (info, copy, test):
             x.add_argument("object", type=render_type, help=src_help)
 
-        tgt_help = ("Object to apply the rendering settings to in "
-                    "the form <object>:<id>. Image is assumed if <object>: "
-                    "is omitted. Object can be Image, Project, Dataset, Plate "
-                    "or Screen")
+        tgt_help = ("Objects to apply the rendering settings to")
         for x in (set_cmd, edit):
             x.add_argument("object", type=render_type, help=tgt_help,
                            nargs="+")

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -441,8 +441,6 @@ class RenderControl(BaseControl):
         for (i, c) in newchannels.iteritems():
             if c.label:
                 namedict[i] = c.label
-            if not c.active:
-                continue
             cindices.append(i)
             rangelist.append([c.min, c.max])
             colourlist.append(c.color)
@@ -450,7 +448,17 @@ class RenderControl(BaseControl):
         iids = []
         for img in self.render_images(gateway, args.object, batch=1):
             iids.append(img.id)
-            img.setActiveChannels(
+
+            # Workaround: Calling set_active_channels would disable
+            # channels which are not specified.
+            imgChannels = img.getChannels()
+            for c in range(len(imgChannels)):
+                if (c+1) not in cindices and imgChannels[c].isActive():
+                    cindices.append(c+1)
+                    rangelist.append([None, None])
+                    colourlist.append(None)
+
+            img.set_active_channels(
                 cindices, windows=rangelist, colors=colourlist)
             if greyscale is not None:
                 if greyscale:

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -101,6 +101,7 @@ TEST_HELP = """
 Test that underlying pixel data is available
 """
 
+
 def _set_if_not_none(dictionary, k, v):
     if v is not None:
         dictionary[k] = v
@@ -259,15 +260,16 @@ class RenderControl(BaseControl):
         for x in (info, copy, test):
             x.add_argument("object", type=render_type, help=render_help)
 
-        set_help = ("Object to apply the rendering settings to in form <object>:<id>. "
-                       "Image is assumed if <object>: is omitted.")
+        set_help = ("Object to apply the rendering settings to in "
+                    "form <object>:<id>. Image is assumed if <object>: "
+                    "is omitted.")
         for x in (set_cmd, edit):
             x.add_argument("object", type=render_type, help=set_help)
 
         for x in (copy, set_cmd, edit):
             x.add_argument(
-                "--skipthumbs", help="Don't re-generate thumbnails immediately",
-                action="store_true")
+                "--skipthumbs", help="Don't re-generate thumbnails "
+                                     "immediately", action="store_true")
 
         output_formats = ['plain'] + list(
             pydict_text_io.get_supported_formats())

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -37,16 +37,14 @@ from omero import UnloadedEntityException
 
 HELP = "Tools for working with rendering settings"
 
-INFO_HELP = """
-Show details of a rendering setting
+INFO_HELP = """Show details of a rendering setting
 
     Examples: 
     bin/omero render info RenderingDef:1
     bin/omero render info Image:123
 """
 
-COPY_HELP = """
-Copy rendering setting to multiple objects
+COPY_HELP = """Copy rendering setting to multiple objects
 
     Examples:
     bin/omero render copy RenderingDef:1 Image:123
@@ -55,12 +53,9 @@ Copy rendering setting to multiple objects
     bin/omero render copy Image:456: Dataset:1
 """
 
-EDIT_HELP = """
-Deprecated, please use 'set' instead
-"""
+EDIT_HELP = "Deprecated, please use 'set' instead"
 
-SET_HELP = """
-Set rendering settings
+SET_HELP = """Set rendering settings
 
     Examples:
     
@@ -97,9 +92,7 @@ Set rendering settings
     # Omitted fields will keep their current values
 """
 
-TEST_HELP = """
-Test that underlying pixel data is available
-"""
+TEST_HELP = "Test that underlying pixel data is available"
 
 
 def _set_if_not_none(dictionary, k, v):


### PR DESCRIPTION
Cleans up some issues with the render plugin, see https://trello.com/c/hPoU5BbW/139-render-plugin-follow-up 

- Removes the `--copy` flag for the `set` command. It is just confusing and the workflow can easily be achived by running `set` on an image and then run the `copy` command afterwards.
- If a channel was not specified in the renderings settings yml/json it was disabled. That's not an expected behaviour. It actually is an issue of the `set_active_channels` method in the gateway https://github.com/openmicroscopy/openmicroscopy/blob/1ecd0f0f96f39f1e8575d3d424e479ac2bda3dc8/components/tools/OmeroPy/src/omero/gateway/__init__.py#L8471 , but this PR adds a workaround for that to the render plugin
- Improves the help a bit, by replacing misleading/wrong information and moving the examples from the top-level help text to the help texts of the individual commands.

## Test
Check that the PR fixes the issues mentioned on the trello card above.

/cc @pwalczysko 
