### PR TITLE
Add disable option to set command

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -300,14 +300,15 @@ class RenderControl(BaseControl):
 
         copy.add_argument("target", type=render_type, help=tgt_help,
                           nargs="+")
-        set_cmd.add_argument(
-            "channels",
-            help="Local file or OriginalFile:ID which specifies the "
-                 "rendering settings")
-        edit.add_argument(
-            "channels",
-            help="Local file or OriginalFile:ID which specifies the "
-                 "rendering settings")
+
+        for x in (set_cmd, edit):
+            x.add_argument(
+                "--disable", help="Disable non specified channels ",
+                action="store_true")
+            x.add_argument(
+                "channels",
+                help="Local file or OriginalFile:ID which specifies the "
+                     "rendering settings")
 
         test.add_argument(
             "--force", action="store_true",
@@ -503,16 +504,16 @@ class RenderControl(BaseControl):
         for img in self.render_images(gateway, args.object, batch=1):
             iids.append(img.id)
 
-            # TODO: Remove again once there's an appropriate gateway method
-            # Workaround: Calling set_active_channels would disable
-            # channels which are not specified.
-            img_channels = img.getChannels()
-            for c in range(len(img_channels)):
-                if (c+1) not in cindices and -(c+1) not in cindices\
-                        and img_channels[c].isActive():
-                    cindices.append(c+1)
-                    rangelist.append([None, None])
-                    colourlist.append(None)
+            if not args.disable:
+                # Calling set_active_channels will disable channels which
+                # are not specified, so have to add them explicitly
+                imgChannels = img.getChannels()
+                for c in range(len(imgChannels)):
+                    if (c+1) not in cindices and -(c+1) not in cindices\
+                            and imgChannels[c].isActive():
+                        cindices.append(c+1)
+                        rangelist.append([None, None])
+                        colourlist.append(None)
 
             img.set_active_channels(
                 cindices, windows=rangelist, colors=colourlist)

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -507,10 +507,10 @@ class RenderControl(BaseControl):
             if not args.disable:
                 # Calling set_active_channels will disable channels which
                 # are not specified, so have to add them explicitly
-                imgChannels = img.getChannels()
-                for c in range(len(imgChannels)):
+                imgchannels = img.getChannels()
+                for c in range(len(imgchannels)):
                     if (c+1) not in cindices and -(c+1) not in cindices\
-                            and imgChannels[c].isActive():
+                            and imgchannels[c].isActive():
                         cindices.append(c+1)
                         rangelist.append([None, None])
                         colourlist.append(None)


### PR DESCRIPTION
Adds a `--disable` option to the `set` command, which if set, deactivates all channels which are not specified in the rendering settings file.

**Test:**
For an image with e.g. 3 active channels: Create a renderings settings json/yml, which specifies 2 channels. Run the `set` command without `--disable` flag:
 `./omero set Image:123 settings.json` - Check that the settings are applied and the third channel is still active.

Change the rendering settings a bit, then use the `--disable` flag:
`./omero set --disable Image:123 settings.json` - Check that the settings are applied but this time the third channel is deactivated.

