### PR TITLE
0.3.1 release preparation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,10 @@ before_install:
 
 script:
   - .omero/cli-docker
+
+deploy:
+  provider: pypi
+  user: ${CI_DEPLOY_USER}
+  password: ${CI_DEPLOY_PASS}
+  on:
+    tags: true

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = '0.3.1.dev1'
+version = '0.3.1'
 url = "https://github.com/ome/omero-cli-render/"
 
 setup(


### PR DESCRIPTION
Proposes to releases the latest bug fixes (#9, #12 and #13) as `omero-cli-render:0.3.1`

Additionally ecdf7d2 includes the prototype to deploy tags to PyPI via Travis and secure environment variables as we have done for bio-formats-examples. In terms of workflow, this means the release process would be slightly simplified as follows:

- bump the `version` variable via commit/PR
- create a signed tag on the commit with the non development version and push to GitHub
- the Travis tag build should then build and upload to PyPI
- bump the `version` to the next development segment via commit/PR

Feedback welcome on this strategy as we could extend it to other Python modules.