### PR TITLE
Some bugfixes

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -531,7 +531,7 @@ class RenderControl(BaseControl):
             reactivatechannels = []
             if not args.disable:
                 # Calling set_active_channels will disable channels which
-                # are not specified, have to keep track of them and 
+                # are not specified, have to keep track of them and
                 # re-activate them later again
                 imgchannels = img.getChannels()
                 for ci, ch in enumerate(imgchannels, 1):

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -514,7 +514,6 @@ class RenderControl(BaseControl):
         rangelist = []
         colourlist = []
         for (i, c) in newchannels.iteritems():
-            i += 1
             if c.label:
                 namedict[i] = c.label
             if c.active is False:

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -126,6 +126,9 @@ TEST_HELP = """Test that underlying pixel data is available
     bin/omero render test Image:1
 """
 
+# Current version for specifying rendering settings
+currentSpecVersion = 2
+
 
 def _set_if_not_none(dictionary, k, v):
     if v is not None:
@@ -260,8 +263,9 @@ class RenderObject(object):
         """
         d = {}
         chs = {}
-        for idx, ch in enumerate(self.channels):
+        for idx, ch in enumerate(self.channels, 1):
             chs[idx] = ch.to_dict()
+        d['version'] = currentSpecVersion
         d['channels'] = chs
         d['greyscale'] = True if self.model == 'greyscale' else False
         return d
@@ -484,6 +488,23 @@ class RenderControl(BaseControl):
         if 'channels' not in data:
             self.ctx.die(104, "ERROR: No channels found in %s" % args.channels)
 
+        # Previously min/max was used to set the channel window start/end
+        # From version 2 on start/end will be used.
+        if 'version' not in data:
+            for chindex, chdict in data['channels'].iteritems():
+                if ('start' in chdict or 'end' in chdict) and\
+                        ('min' in chdict or 'max' in chdict):
+                    self.ctx.die(124, "ERROR: start/end and min/max specified,"
+                                      " cannot determine version.")
+                if 'start' in chdict or 'end' in chdict:
+                    version = 2
+                    break
+                if 'min' in chdict or 'max' in chdict:
+                    version = 1
+                    break
+        else:
+            version = data['version']
+
         for chindex, chdict in data['channels'].iteritems():
             try:
                 cindex = int(chindex)
@@ -496,6 +517,9 @@ class RenderControl(BaseControl):
                 cobj = ChannelObject(chdict)
                 if (cobj.min is None) != (cobj.max is None):
                     raise Exception('Both or neither of min and max required')
+                if (cobj.start is None) != (cobj.end is None):
+                    raise Exception('Both or neither of start and end '
+                                    'required')
                 newchannels[cindex] = cobj
                 print '%d:%s' % (cindex, cobj)
             except Exception as e:
@@ -520,7 +544,9 @@ class RenderControl(BaseControl):
                 cindices.append(-i)
             else:
                 cindices.append(i)
-            rangelist.append([c.start, c.end])
+            start = c.start if version > 1 else c.min
+            end = c.end if version > 1 else c.max
+            rangelist.append([start, end])
             colourlist.append(c.color)
 
         iids = []

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -115,26 +115,26 @@ class TestRender(CLITest):
         channels[1] = {
             'label': self.uuid(),
             'color': '123456',
-            'min': 11,
-            'max': 22,
+            'start': 11,
+            'end': 22,
         }
         channels[2] = {
             'label': self.uuid(),
             'color': '789ABC',
-            'min': 33,
-            'max': 44,
+            'start': 33,
+            'end': 44,
         }
         channels[3] = {
             'label': self.uuid(),
             'color': 'DEF012',
-            'min': 55,
-            'max': 66,
+            'start': 55,
+            'end': 66,
         }
         channels[4] = {
             'label': self.uuid(),
             'color': '345678',
-            'min': 77,
-            'max': 88,
+            'start': 77,
+            'end': 88,
         }
 
         for k in xrange(sizec, 4):
@@ -148,8 +148,8 @@ class TestRender(CLITest):
     def assert_channel_rdef(self, channel, rdef):
         assert channel.getLabel() == rdef['label']
         assert channel.getColor().getHtml() == rdef['color']
-        assert channel.getWindowStart() == rdef['min']
-        assert channel.getWindowEnd() == rdef['max']
+        assert channel.getWindowStart() == rdef['start']
+        assert channel.getWindowEnd() == rdef['end']
 
     def assert_image_rmodel(self, img, greyscale):
         assert img.isGreyscaleRenderingModel() == greyscale

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -161,6 +161,18 @@ class TestRender(CLITest):
     # rendering tests
     # ========================================================================
 
+    @pytest.mark.permissions
+    def test_cross_group(self, capsys):
+        self.create_image(sizec=1)
+        login = self.root_login_args()
+        # Run test as self and as root
+        self.cli.invoke(self.args + ["test", self.imageid], strict=True)
+        self.cli.invoke(login + ["render", "test", self.imageid], strict=True)
+        out, err = capsys.readouterr()
+        lines = out.split("\n")
+        assert "ok" in lines[0]
+        assert "ok" in lines[1]
+
     @pytest.mark.parametrize('target_name', sorted(SUPPORTED.keys()))
     def test_non_existing_image(self, target_name, tmpdir):
         target = SUPPORTED[target_name]
@@ -260,15 +272,3 @@ class TestRender(CLITest):
             self.assert_image_rmodel(img, expected_greyscale)
             # img._closeRE()
         # assert not gw._assert_unregistered("testEditSingleC")
-
-    @pytest.mark.permissions
-    def test_cross_group(self, capsys):
-        self.create_image(sizec=1)
-        login = self.root_login_args()
-        # Run test as self and as root
-        self.cli.invoke(self.args + ["test", self.imageid], strict=True)
-        self.cli.invoke(login + ["render", "test", self.imageid], strict=True)
-        out, err = capsys.readouterr()
-        lines = out.split("\n")
-        assert "ok" in lines[0]
-        assert "ok" in lines[1]


### PR DESCRIPTION
This PR fixes some bugs I noticed while trying to export ('render info') and apply ('render set') the rendering settings of idr0044:

- The channel index was off by 1 (when setting the name and activate/deactivate)
- 'info' command output used 0-based index, whereas the 'set' command expects 1-based index for the channels
- start and end values specified in the yaml were ignored (when setting the rendering settings)
- Instead of start/end the min/max values specified in the yaml were set as window start/end.
- If a channel is not specified in the yaml it is deactivated by the the `set_active_channels` method. I added a workround earlier, which is not buggy (afaik) but I changed it a bit, so its clearer and safer.

**Test**: With this PR it should now be possible to adjust the rendering settings of an image in OMERO.web. Then export them with `./omero render info --style yaml Image:ID > renderingsettings.yml` And then reapply them with `./omero render set  Image:ID renderingsettings.yml`. The renderings settings should then be the same.

This PR adds support for a 'version' field in the yml/json. If rendering settings specify start/end and min/max you have to add the version, otherwise it's not clear which values to use for the channel window start/end. Earlier versions used min/max, but with this version (version 2) start/end will be used.
