### PR TITLE
Improve versioning code

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -199,8 +199,8 @@ class ChannelObject(object):
         self.color = d.get('color', None)
         self.min = float(d['min']) if 'min' in d else None
         self.max = float(d['max']) if 'max' in d else None
-        self.start = float(d['start']) if self.version == 2 else self.min
-        self.end = float(d['end']) if self.version == 2 else self.max
+        self.start = float(d['start']) if self.version > 1 else self.min
+        self.end = float(d['end']) if self.version > 1 else self.max
         self.active = bool(d.get('active', True))
 
     def __str__(self):

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -137,9 +137,8 @@ def _set_if_not_none(dictionary, k, v):
 
 
 def _getversion(data):
-    """ Returns the version of the rendering settings format.
-    If the version cannot be determined 'self.ctx.die' will
-    be called.
+    """ Returns the version of the rendering settings format
+    or 0 if it cannot be determined.
 
     Arguments:
     data -- The rendering settings as dictionary
@@ -151,16 +150,14 @@ def _getversion(data):
         for chindex, chdict in data['channels'].iteritems():
             if ('start' in chdict or 'end' in chdict) and\
                ('min' in chdict or 'max' in chdict):
-                self.ctx.die(124, "ERROR: start/end and min/max specified,"
-                                  " cannot determine version.")
+                return 0
             if 'start' in chdict or 'end' in chdict:
                 return 2
             if 'min' in chdict or 'max' in chdict:
                 return 1
     else:
         return data['version']
-
-    self.ctx.die(124, "ERROR: Either start/end or min/max must be specified.")
+    return 0
 
 
 class ChannelObject(object):
@@ -189,6 +186,10 @@ class ChannelObject(object):
 
     def init_from_dict(self, d):
         version = _getversion(d)
+        if version == 0:
+            self.ctx.die(124, "ERROR: Cannot determine version. Specify"
+                              "version or use either start/end or min/max"
+                              " (not both).")
         self.emWave = None
         self.label = d.get('label', None)
         self.color = d.get('color', None)

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -136,7 +136,7 @@ def _set_if_not_none(dictionary, k, v):
         dictionary[k] = v
 
 
-def _getVersion(self, data):
+def _getversion(self, data):
     """ Returns the version of the rendering settings format.
     If the version cannot be determined 'self.ctx.die' will
     be called.
@@ -188,7 +188,7 @@ class ChannelObject(object):
         self.active = channel.isActive()
 
     def init_from_dict(self, d):
-        version = _getVersion(d)
+        version = _getversion(d)
         self.emWave = None
         self.label = d.get('label', None)
         self.color = d.get('color', None)

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -523,7 +523,7 @@ class RenderControl(BaseControl):
         version = _getversion(data)
         if version == 0:
             self.ctx.die(124, "ERROR: Cannot determine version. Specify"
-                              "version or use either start/end or min/max"
+                              " version or use either start/end or min/max"
                               " (not both).")
 
         for chindex, chdict in data['channels'].iteritems():

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -136,7 +136,7 @@ def _set_if_not_none(dictionary, k, v):
         dictionary[k] = v
 
 
-def _getversion(self, data):
+def _getversion(data):
     """ Returns the version of the rendering settings format.
     If the version cannot be determined 'self.ctx.die' will
     be called.


### PR DESCRIPTION
Follow up to #15 .
- Moved the version check code into a separate function
- Check the version in the ChannelObject directly, so other code should not be affected by the versioning.
