### PR TITLE
Integration tests review

### DIFF
--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -173,7 +173,9 @@ class TestRender(CLITest):
             channels = img.getChannels()
             assert len(channels) == len(rdef['channels'])
             for c in xrange(len(channels)):
-                self.assert_channel_rdef(channels[c], rdef['channels'][c + 1])
+                self.assert_channel_rdef(
+                    channels[c], rdef['channels'][c + 1],
+                    version=rdef['version'])
 
             if rdef.get('greyscale', None) is None:
                 if len(channels) == 1:
@@ -183,11 +185,11 @@ class TestRender(CLITest):
             else:
                 self.assert_image_rmodel(img, rdef.get('greyscale'))
 
-    def assert_channel_rdef(self, channel, rdef):
+    def assert_channel_rdef(self, channel, rdef, version=2):
         assert channel.getLabel() == rdef['label']
         assert channel.getColor().getHtml() == rdef['color']
-        start = rdef['start'] if rdef['version'] > 1 else rdef['min']
-        end = rdef['end'] if rdef['version'] > 1 else rdef['max']
+        start = rdef['start'] if version > 1 else rdef['min']
+        end = rdef['end'] if version > 1 else rdef['max']
         assert channel.getWindowStart() == start
         assert channel.getWindowEnd() == end
 

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -91,7 +91,8 @@ class TestRender(CLITest):
             self.projectid = "Project:%s" % self.project.id
             self.datasetid = "Dataset:%s" % self.dataset.id
             self.link(obj1=project, obj2=dataset)
-            self.link(obj1=dataset, obj2=images)
+            for i in images:
+                self.link(obj1=dataset, obj2=i)
 
     def get_target_imageids(self, target):
         if target in (self.idonly, self.imageid):

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -156,6 +156,7 @@ class TestRender(CLITest):
 
         if greyscale is not None:
             d['greyscale'] = greyscale
+        d['version'] = version
         return d
 
     def assert_target_rdef(self, target, rdef):
@@ -182,11 +183,11 @@ class TestRender(CLITest):
             else:
                 self.assert_image_rmodel(img, rdef.get('greyscale'))
 
-    def assert_channel_rdef(self, channel, rdef, version=2):
+    def assert_channel_rdef(self, channel, rdef):
         assert channel.getLabel() == rdef['label']
         assert channel.getColor().getHtml() == rdef['color']
-        start = rdef['start'] if version > 1 else rdef['min']
-        end = rdef['end'] if version > 1 else rdef['max']
+        start = rdef['start'] if rdef['version'] > 1 else rdef['min']
+        end = rdef['end'] if rdef['version'] > 1 else rdef['max']
         assert channel.getWindowStart() == start
         assert channel.getWindowEnd() == end
 

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -214,12 +214,13 @@ class TestRender(CLITest):
 
     # Once testSet is no longer broken testSetSingleC could be merged into
     # it with sizec and greyscale parameters
-    @pytest.mark.parametrize('sizec', [1, 2, 3, 4])
+    @pytest.mark.parametrize('sizec', [1, 2, 4])
     @pytest.mark.parametrize('greyscale', [None, True, False])
     @pytest.mark.parametrize('version', [1, 2])
     def test_set(self, sizec, greyscale, version, tmpdir):
         self.create_image(sizec=sizec)
-        rd = self.get_render_def(sizec=sizec, greyscale=greyscale)
+        rd = self.get_render_def(sizec=sizec, greyscale=greyscale,
+                                 version=version)
         rdfile = tmpdir.join('render-test.json')
         # Should work with json and yaml, but yaml is an optional dependency
         rdfile.write(json.dumps(rd))
@@ -238,8 +239,13 @@ class TestRender(CLITest):
         for c in xrange(len(channels)):
             self.assert_channel_rdef(channels[c], rd['channels'][c + 1],
                                      version)
-        expected_greyscale = ((greyscale is None) or greyscale)
-        self.assert_image_rmodel(img, expected_greyscale)
+        if greyscale is None:
+            if sizec == 1:
+                self.assert_image_rmodel(img, True)
+            else:
+                self.assert_image_rmodel(img, False)
+        else:
+            self.assert_image_rmodel(img, greyscale)
 
     @pytest.mark.parametrize('target_name', sorted(SUPPORTED))
     @pytest.mark.parametrize('sizec', [1, 2])


### PR DESCRIPTION
This PR focues on reduce the time spent on integration tests by Travis CI.

The major change is  in 694ce8e. Previously `create_image` was creating multiple images in a SPW and a PDI structure for every integration test. This commit allows to pass a `target_name` so that the container hierarchy is only created when required by the test, defaulting to a simple orphaned image import.

Tests are also reviewed and reduced so that the functionalities are still covered without going explicitly through all combinations of target/rendering settings. The broken tests (which were still executed on every PR) are replaced by testing the passing scenario of 2-channel images in various target containers which does not have the limitation reported previously.

All tests should pass and the overall time should be reduced from ~15min previously. Testing this PR should involve makeing sure we still have coverage of all the functionalities.