### PR TITLE
Enable setting defaultZ/defaultT

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -532,8 +532,8 @@ class RenderControl(BaseControl):
                               " version or use either start/end or min/max"
                               " (not both).")
 
-        defZ = data['z'] if 'z' in data else None
-        defT = data['t'] if 't' in data else None
+        def_z = data['z'] if 'z' in data else None
+        def_t = data['t'] if 't' in data else None
 
         for chindex, chdict in data['channels'].iteritems():
             try:
@@ -598,10 +598,10 @@ class RenderControl(BaseControl):
             if len(reactivatechannels) > 0:
                 img.set_active_channels(reactivatechannels)
 
-            if defZ:
-                img.setDefaultZ(defZ-1)
-            if defT:
-                img.setDefaultT(defT-1)
+            if def_z:
+                img.setDefaultZ(def_z - 1)
+            if def_t:
+                img.setDefaultT(def_t - 1)
 
             img.saveDefaults()
             self.ctx.dbg(

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -302,6 +302,8 @@ class RenderObject(object):
         for idx, ch in enumerate(self.channels, 1):
             chs[idx] = ch.to_dict()
         d['version'] = SPEC_VERSION
+        d['z'] = int(self.defaultZ+1)
+        d['t'] = int(self.defaultT+1)
         d['channels'] = chs
         d['greyscale'] = True if self.model == 'greyscale' else False
         return d
@@ -530,6 +532,9 @@ class RenderControl(BaseControl):
                               " version or use either start/end or min/max"
                               " (not both).")
 
+        defZ = data['z'] if 'z' in data else None
+        defT = data['t'] if 't' in data else None
+
         for chindex, chdict in data['channels'].iteritems():
             try:
                 cindex = int(chindex)
@@ -592,6 +597,11 @@ class RenderControl(BaseControl):
 
             if len(reactivatechannels) > 0:
                 img.set_active_channels(reactivatechannels)
+
+            if defZ:
+                img.setDefaultZ(defZ-1)
+            if defT:
+                img.setDefaultT(defT-1)
 
             img.saveDefaults()
             self.ctx.dbg(

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -156,10 +156,10 @@ class TestRender(CLITest):
 
         if greyscale is not None:
             d['greyscale'] = greyscale
-        if defaultt:
-            d['t'] = defaultt
-        if defaultz:
-            d['z'] = defaultz
+        if t:
+            d['t'] = t
+        if z:
+            d['z'] = z
         for k in xrange(sizec, 4):
             del channels[k + 1]
         d['version'] = version
@@ -191,8 +191,14 @@ class TestRender(CLITest):
             else:
                 self.assert_image_rmodel(img, rdef.get('greyscale'))
 
-            assert img.getDefaultT() == rdef.get('t', (int) img.getSizeT() / 2)
-            assert img.getDefaultZ() == rdef.get('z', (int) img.getSizeZ() / 2)
+            if 't' in rdef:
+                assert img.getDefaultT() == rdef.get('t') - 1
+            else:
+                assert img.getDefaultT() == (int)(img.getSizeT() / 2)
+            if 'z' in rdef:
+                assert img.getDefaultZ() == rdef.get('z') - 1
+            else:
+                assert img.getDefaultT() == (int)(img.getSizeZ() / 2)
 
     def assert_channel_rdef(self, channel, rdef, version=2):
         assert channel.getLabel() == rdef['label']
@@ -283,7 +289,7 @@ class TestRender(CLITest):
         self.assert_target_rdef(target, rd)
 
     @pytest.mark.parametrize('z', [None, 2, 5])
-    @pytest.mark.parametrize('t', [None, 0, 12])
+    @pytest.mark.parametrize('t', [None, 1, 12])
     def test_set_defaults(self, z, t, tmpdir):
         self.create_image(sizez=10, sizet=15)
         rd = self.get_render_def(z=z, t=t)

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -124,7 +124,7 @@ class TestRender(CLITest):
         raise Exception('Unknown target: %s' % target)
 
     def get_render_def(self, sizec=4, greyscale=None, version=2, windows=True,
-                       defaultz=None, defaultt=None):
+                       z=None, t=None):
         # Define channels with labels and colors
         channels = {}
         channels[1] = {
@@ -159,7 +159,7 @@ class TestRender(CLITest):
         if defaultt:
             d['t'] = defaultt
         if defaultz:
-            d['Z'] = defaultz
+            d['z'] = defaultz
         for k in xrange(sizec, 4):
             del channels[k + 1]
         d['version'] = version
@@ -191,10 +191,8 @@ class TestRender(CLITest):
             else:
                 self.assert_image_rmodel(img, rdef.get('greyscale'))
 
-            if 't' in rdef:
-                assert img.getDefaultT() == rdef.get('t')
-            if 'z' in rdef:
-                assert img.getDefaultZ() == rdef.get('z')
+            assert img.getDefaultT() == rdef.get('t', (int) img.getSizeT() / 2)
+            assert img.getDefaultZ() == rdef.get('z', (int) img.getSizeZ() / 2)
 
     def assert_channel_rdef(self, channel, rdef, version=2):
         assert channel.getLabel() == rdef['label']
@@ -284,10 +282,11 @@ class TestRender(CLITest):
         self.cli.invoke(self.args, strict=True)
         self.assert_target_rdef(target, rd)
 
-    @pytest.mark.parametrize('defaultz', [0, 2, 9])
-    def test_set_defaultz(self, defaultz, tmpdir):
-        self.create_image(sizez=10)
-        rd = self.get_render_def(defaultz=defaultz)
+    @pytest.mark.parametrize('z', [None, 2, 5])
+    @pytest.mark.parametrize('t', [None, 0, 12])
+    def test_set_defaults(self, z, t, tmpdir):
+        self.create_image(sizez=10, sizet=15)
+        rd = self.get_render_def(z=z, t=t)
         rdfile = tmpdir.join('render-test-setdefaultz.json')
         rdfile.write(json.dumps(rd))
         self.args += ["set", self.idonly, str(rdfile)]

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -194,11 +194,13 @@ class TestRender(CLITest):
             if 't' in rdef:
                 assert img.getDefaultT() == rdef.get('t') - 1
             else:
-                assert img.getDefaultT() == (int)(img.getSizeT() / 2)
+                # If not set, default T plane is the first one
+                assert img.getDefaultT() == 0
             if 'z' in rdef:
                 assert img.getDefaultZ() == rdef.get('z') - 1
             else:
-                assert img.getDefaultT() == (int)(img.getSizeZ() / 2)
+                # If not set, default Z plane is the middle one
+                assert img.getDefaultZ() == (int)(img.getSizeZ() / 2)
 
     def assert_channel_rdef(self, channel, rdef, version=2):
         assert channel.getLabel() == rdef['label']


### PR DESCRIPTION
Fixes #16 
 
Allows specifying defaultZ/defaultT, as `z` and `t` (1 based index).
