### PR TITLE
Default Z/T planes: validation

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -536,15 +536,13 @@ class RenderControl(BaseControl):
             self.ctx.die(
                 105, "Invalid default T plane: %s" % def_t)
 
-        # Validate plane index with image dimensions
+        # Validate default plane index against image dimensions
         if def_z and def_z > img.getSizeZ():
             msg = ("Inconsistent default Z plane. Expected to set %s but the"
                    " image dimension is %s" % (def_z, img.getSizeZ()))
             if not ignore_errors:
                 self.ctx.die(106, msg)
             else:
-                # Attempt to auto-correct the default T plane for single
-                # timepoint images
                 self.ctx.dbg(msg + ". Ignoring.")
                 def_z = None
         if def_t and def_t > img.getSizeT():
@@ -553,8 +551,6 @@ class RenderControl(BaseControl):
             if not ignore_errors:
                 self.ctx.die(106, msg)
             else:
-                # Attempt to auto-correct the default T plane for single
-                # timepoint images
                 self.ctx.dbg(msg + ". Ignoring.")
                 def_t = None
         return (def_z, def_t)

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -532,9 +532,17 @@ class RenderControl(BaseControl):
                               " version or use either start/end or min/max"
                               " (not both).")
 
+        # Read default planes from rendering dictionary
         def_z = data['z'] if 'z' in data else None
         def_t = data['t'] if 't' in data else None
+        if def_z < 0 of int(def_z) != def_z:
+            self.ctx.die(
+                105, "Invalid default Z plane: %s" % def_z)
+        if def_t < 0 of int(def_t) != def_t:
+            self.ctx.die(
+                105, "Invalid default T plane: %s" % def_t)
 
+        # Read channel setttings from rendering dictionary
         for chindex, chdict in data['channels'].iteritems():
             try:
                 cindex = int(chindex)

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -529,10 +529,10 @@ class RenderControl(BaseControl):
         def_t = data['t'] if 't' in data else None
 
         # Minimal validation: default planes should be 1-indexed integers
-        if def_z and (def_z < 0 or int(def_z) != def_z):
+        if def_z and (def_z < 1 or int(def_z) != def_z):
             self.ctx.die(
                 105, "Invalid default Z plane: %s" % def_z)
-        if def_t and (def_t < 0 or int(def_t) != def_t):
+        if def_t and (def_t < 1 or int(def_t) != def_t):
             self.ctx.die(
                 105, "Invalid default T plane: %s" % def_t)
 

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -541,7 +541,7 @@ class RenderControl(BaseControl):
             msg = ("Inconsistent default Z plane. Expected to set %s but the"
                    " image dimension is %s" % (def_z, img.getSizeZ()))
             if not ignore_errors:
-                self.ctx.die(msg)
+                self.ctx.die(106, msg)
             else:
                 # Attempt to auto-correct the default T plane for single
                 # timepoint images
@@ -551,7 +551,7 @@ class RenderControl(BaseControl):
             msg = ("Inconsistent default T plane. Expected to set %s but the"
                    " image dimension is %s" % (def_t, img.getSizeT()))
             if not ignore_errors:
-                self.ctx.die(107, msg)
+                self.ctx.die(106, msg)
             else:
                 # Attempt to auto-correct the default T plane for single
                 # timepoint images

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -80,28 +80,33 @@ SET_HELP = """Set rendering settings
     # key (required), and an optional top-level greyscale key (True: greyscale,
     # False: color). Channel elements are index:dictionaries of the form:
 
-    channels:
-      <index>: (Channel-index, int, 1-based)
-        color: <HTML RGB triplet>
-        label: <Channel name>
-        min: <Minimum (float)>
-        max: <Maximum (float)>
-        active: <Active (bool)>
-      <index>:
+    channels:                       Required
+      <int>:                        Channel index, 1-based
+        active: <bool>              Active channel
+        color: <string>             Channel color as HTML RGB triplet
+        label: <string>             Channel name
+        start: <float>              Start of the rendering window, optional
+        end: <float>                End of the rendering window, optional
+      <int>:
         ...
-    greyscale: <(bool)>
+    greyscale: <bool>               Greyscale rendering, optional
+    z: <int>                        Default Z plane index, 1-based, optional
+    t: <int>                        Default T plane index, 1-based, optional
 
     For example:
+
     channels:
       1:
         color: "FF0000"
         label: "Red"
-        min: 1
-        max: 255
+        start: 10.0
+        end: 248.0
         active: True
       2:
         color: "00FF00"
       ...
+    z: 5
+    t: 1
 
     # Omitted fields will keep their current values.
     # If the file specifies to turn off a channel (active: False) then the

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -529,10 +529,10 @@ class RenderControl(BaseControl):
         def_t = data['t'] if 't' in data else None
 
         # Minimal validation: default planes should be 1-indexed integers
-        if def_z and (def_z < 1 or int(def_z) != def_z):
+        if (def_z is not None) and (def_z < 1 or int(def_z) != def_z):
             self.ctx.die(
                 105, "Invalid default Z plane: %s" % def_z)
-        if def_t and (def_t < 1 or int(def_t) != def_t):
+        if (def_t is not None) and (def_t < 1 or int(def_t) != def_t):
             self.ctx.die(
                 105, "Invalid default T plane: %s" % def_t)
 

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -535,10 +535,10 @@ class RenderControl(BaseControl):
         # Read default planes from rendering dictionary
         def_z = data['z'] if 'z' in data else None
         def_t = data['t'] if 't' in data else None
-        if def_z < 0 of int(def_z) != def_z:
+        if def_z < 0 or int(def_z) != def_z:
             self.ctx.die(
                 105, "Invalid default Z plane: %s" % def_z)
-        if def_t < 0 of int(def_t) != def_t:
+        if def_t < 0 or int(def_t) != def_t:
             self.ctx.die(
                 105, "Invalid default T plane: %s" % def_t)
 

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -563,10 +563,10 @@ class RenderControl(BaseControl):
         # Read default planes from rendering dictionary
         def_z = data['z'] if 'z' in data else None
         def_t = data['t'] if 't' in data else None
-        if def_z < 0 or int(def_z) != def_z:
+        if def_z and (def_z < 0 or int(def_z) != def_z):
             self.ctx.die(
                 105, "Invalid default Z plane: %s" % def_z)
-        if def_t < 0 or int(def_t) != def_t:
+        if def_t and (def_t < 0 or int(def_t) != def_t):
             self.ctx.die(
                 105, "Invalid default T plane: %s" % def_t)
 

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -333,6 +333,6 @@ class TestRender(CLITest):
             self.cli.invoke(self.args, strict=True)
 
         # With ignore-errors, the default planes should be ignored
-        self.args += ["set", "--ignore-errors", self.idonly, str(rdfile)]
+        self.args += ["--ignore-errors"]
         self.cli.invoke(self.args, strict=True)
         self.assert_target_rdef(self.idonly, rd)

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -295,35 +295,35 @@ class TestRender(CLITest):
     def test_set_defaults(self, z, t, tmpdir):
         self.create_image(sizez=10, sizet=15)
         rd = self.get_render_def(z=z, t=t)
-        rdfile = tmpdir.join('render-test-setdefaultz.json')
+        rdfile = tmpdir.join('render-test-setdefaults.json')
         rdfile.write(json.dumps(rd))
         self.args += ["set", self.idonly, str(rdfile)]
         self.cli.invoke(self.args, strict=True)
         self.assert_target_rdef(self.idonly, rd)
 
-    @pytest.mark.parametrize('value', [0, 0.5])
-    def test_invalid_defaults(self, value, tmpdir):
+    @pytest.mark.parametrize('invalid_value', [0, 0.5])
+    def test_set_invalid_defaults(self, invalid_value, tmpdir):
         self.create_image()
-        rd = self.get_render_def(z=value)
-        rdfile = tmpdir.join('render-test-setdefaultz.json')
+        rd = self.get_render_def(z=invalid_value)
+        rdfile = tmpdir.join('render-test-setinvaliddefaults.json')
         rdfile.write(json.dumps(rd))
         self.args += ["set", self.idonly, str(rdfile)]
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
-        rd = self.get_render_def(t=value)
-        rdfile = tmpdir.join('render-test-setdefaultz.json')
+        rd = self.get_render_def(t=invalid_value)
+        rdfile = tmpdir.join('render-test-setinvaliddefaults.json')
         rdfile.write(json.dumps(rd))
         self.args += ["set", self.idonly, str(rdfile)]
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
     @pytest.mark.parametrize('z, t', [
-        (6, None), (6, 8), [None, 8)]])
-    def test_invalid_defaults2(self, z, t, tmpdir):
+        (6, None), (6, 8), (None, 8)])
+    def test_set_invalid_defaults2(self, z, t, tmpdir):
         self.create_image(sizez=5, sizet=6)
         rd = self.get_render_def(z=z, t=t)
-        rdfile = tmpdir.join('render-test-invaliddefaults2.json')
+        rdfile = tmpdir.join('render-test-setinvaliddefaults2.json')
         rdfile.write(json.dumps(rd))
 
         # Default behavior should be to error on mismatching

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -300,3 +300,20 @@ class TestRender(CLITest):
         self.args += ["set", self.idonly, str(rdfile)]
         self.cli.invoke(self.args, strict=True)
         self.assert_target_rdef(self.idonly, rd)
+
+    @pytest.mark.parametrize('value', [0, 0.5])
+    def test_invalid_defaults(self, value, tmpdir):
+        self.create_image()
+        rd = self.get_render_def(z=value)
+        rdfile = tmpdir.join('render-test-setdefaultz.json')
+        rdfile.write(json.dumps(rd))
+        self.args += ["set", self.idonly, str(rdfile)]
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke(self.args, strict=True)
+
+        rd = self.get_render_def(t=value)
+        rdfile = tmpdir.join('render-test-setdefaultz.json')
+        rdfile.write(json.dumps(rd))
+        self.args += ["set", self.idonly, str(rdfile)]
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke(self.args, strict=True)

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -317,3 +317,22 @@ class TestRender(CLITest):
         self.args += ["set", self.idonly, str(rdfile)]
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
+
+    @pytest.mark.parametrize('z, t', [
+        (6, None), (6, 8), [None, 8)]])
+    def test_invalid_defaults2(self, z, t, tmpdir):
+        self.create_image(sizez=5, sizet=6)
+        rd = self.get_render_def(z=z, t=t)
+        rdfile = tmpdir.join('render-test-invaliddefaults2.json')
+        rdfile.write(json.dumps(rd))
+
+        # Default behavior should be to error on mismatching
+        # plane index/image dimensions
+        self.args += ["set", self.idonly, str(rdfile)]
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke(self.args, strict=True)
+
+        # With ignore-errors, the default planes should be ignored
+        self.args += ["set", "--ignore-errors", self.idonly, str(rdfile)]
+        self.cli.invoke(self.args, strict=True)
+        self.assert_target_rdef(self.idonly, rd)

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -191,12 +191,12 @@ class TestRender(CLITest):
             else:
                 self.assert_image_rmodel(img, rdef.get('greyscale'))
 
-            if 't' in rdef:
+            if 't' in rdef and rdef['t'] <= img.getSizeT():
                 assert img.getDefaultT() == rdef.get('t') - 1
             else:
                 # If not set, default T plane is the first one
                 assert img.getDefaultT() == 0
-            if 'z' in rdef:
+            if 'z' in rdef and rdef['z'] <= img.getSizeZ():
                 assert img.getDefaultZ() == rdef.get('z') - 1
             else:
                 # If not set, default Z plane is the middle one

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -156,9 +156,9 @@ class TestRender(CLITest):
 
         if greyscale is not None:
             d['greyscale'] = greyscale
-        if t:
+        if t is not None:
             d['t'] = t
-        if z:
+        if z is not None:
             d['z'] = z
         for k in xrange(sizec, 4):
             del channels[k + 1]


### PR DESCRIPTION
Follow-up of #23, this adds some validation and error handling when default Z/T planes are passed via the `render set` command.

- if the plane index is completely invalid (0 or less or non-integer value), fails with an error code
- if the plane index is large than the image dimension, two behaviors are implemented depending on whether a lenient `--ignore-errors` flag is passed to the command
   * by default (strict), the assumption is that the rendering dictionary matches the image dimensions and an error is thrown
   * if `--ignore-errors` is passed, the default plane is ignored

Integration tests are also added to cover the two behaviors described above.