### PR TITLE
Make 'info' output yamllint compatible

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -20,6 +20,7 @@
 
 import sys
 import time
+import yaml
 
 from functools import wraps
 
@@ -466,6 +467,10 @@ class RenderControl(BaseControl):
             ro = RenderObject(img)
             if args.style == 'plain':
                 self.ctx.out(ro)
+            elif args.style == 'yaml':
+                self.ctx.out(yaml.dump(ro.to_dict(), explicit_start=True,
+                             width=80, indent=4,
+                             default_flow_style=False).rstrip())
             else:
                 if not first:
                     self.ctx.die(


### PR DESCRIPTION
Fixes #19 

Makes the 'info' command output yamllint compatible.

**Test**:
`./omero render info --style yaml Image:123  > test.yml`
Then `yamllint test.yml` shouldn't report any errors/warnings.

