### PR TITLE
Add Python3 support to the render plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ sudo: required
 services:
   - docker
 
-env:
-  - OMERO_SERVER_VERSION=5.6.0-m1-0
-
 before_install:
   - git clone --recurse-submodules git://github.com/openmicroscopy/omero-test-infra .omero
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: required
 services:
   - docker
 
+env:
+  - OMERO_SERVER_VERSION=5.6.0-m1-0
+
 before_install:
   - git clone --recurse-submodules git://github.com/openmicroscopy/omero-test-infra .omero
 

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = '0.4.4.dev1'
+version = '0.5.dev1'
 url = "https://github.com/ome/omero-cli-render/"
 
 setup(
@@ -117,7 +117,11 @@ setup(
     author='The Open Microscopy Team',
     author_email='ome-devel@lists.openmicroscopy.org.uk',
     license='GPL-2.0+',
-    install_requires=['PyYAML'],
+    install_requires=[
+        'PyYAML',
+        'omero-py>=5.6.dev4',
+        'future'
+        ],
     url='%s' % url,
     zip_safe=False,
     download_url='%s/v%s.tar.gz' % (url, version),

--- a/setup.py
+++ b/setup.py
@@ -127,5 +127,5 @@ setup(
     download_url='%s/v%s.tar.gz' % (url, version),
     keywords=['OMERO.CLI', 'plugin'],
     cmdclass={'test': PyTest},
-    tests_require=['pytest', 'restview', 'mox'],
+    tests_require=['pytest', 'restview', 'mox3'],
 )

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -18,6 +18,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from __future__ import print_function
+from past.builtins import long
+from builtins import str
+from builtins import range
+from builtins import object
 import sys
 import time
 import yaml
@@ -156,7 +161,7 @@ def _getversion(dictionary):
     """
 
     if 'version' not in dictionary:
-        for chindex, chdict in dictionary['channels'].iteritems():
+        for chindex, chdict in dictionary['channels'].items():
             if ('start' in chdict or 'end' in chdict) and\
                ('min' in chdict or 'max' in chdict):
                 return 0
@@ -286,8 +291,8 @@ class RenderObject(object):
             self.zoomLevelScaling = image.getZoomLevelScaling()
 
         self.range = image.getPixelRange()
-        self.channels = map(lambda x: ChannelObject(x),
-                            image.getChannels(noRE=False))
+        self.channels = [
+            ChannelObject(x) for x in image.getChannels(noRE=False)]
         self.model = image.isGreyscaleRenderingModel() and \
             'greyscale' or 'color'
         self.projection = image.getProjection()
@@ -512,7 +517,7 @@ class RenderControl(BaseControl):
                     continue
 
                 rv = self.gateway.applySettingsToSet(src_img.id, "Image",
-                                                     batch.keys())
+                                                     list(batch.keys()))
                 for missing in rv[False]:
                     self.ctx.err("Error: Image:%s" % missing)
                     del batch[missing]
@@ -521,7 +526,7 @@ class RenderControl(BaseControl):
                               to %d images." % len(rv[True]))
 
                 if not args.skipthumbs:
-                    self._generate_thumbs(batch.values())
+                    self._generate_thumbs(list(batch.values()))
 
     def update_channel_names(self, gateway, obj, namedict):
         for targets in self.render_images(gateway, obj):
@@ -592,7 +597,7 @@ class RenderControl(BaseControl):
                               " (not both).")
 
         # Read channel setttings from rendering dictionary
-        for chindex, chdict in data['channels'].iteritems():
+        for chindex, chdict in data['channels'].items():
             try:
                 cindex = int(chindex)
             except Exception as e:
@@ -603,7 +608,7 @@ class RenderControl(BaseControl):
             try:
                 cobj = ChannelObject(chdict, version)
                 newchannels[cindex] = cobj
-                print '%d:%s' % (cindex, cobj)
+                print('%d:%s' % (cindex, cobj))
             except Exception as e:
                 self.ctx.err('ERROR: %s' % e)
                 self.ctx.die(
@@ -611,7 +616,7 @@ class RenderControl(BaseControl):
 
         try:
             greyscale = data['greyscale']
-            print 'greyscale=%s' % data['greyscale']
+            print('greyscale=%s' % data['greyscale'])
         except KeyError:
             greyscale = None
 
@@ -619,7 +624,7 @@ class RenderControl(BaseControl):
         cindices = []
         rangelist = []
         colourlist = []
-        for (i, c) in newchannels.iteritems():
+        for (i, c) in newchannels.items():
             if c.label:
                 namedict[i] = c.label
             if c.active is False:
@@ -706,7 +711,7 @@ class RenderControl(BaseControl):
         try:
             rps.setPixelsId(long(pixid), False, fail)
             msg = "ok:"
-        except Exception, e:
+        except Exception as e:
             error = e
             msg = "miss:"
 
@@ -719,7 +724,7 @@ class RenderControl(BaseControl):
             except KeyboardInterrupt:
                 msg = "cancel:"
                 pass
-            except Exception, e:
+            except Exception as e:
                 msg = "fail:"
                 error = e
             finally:
@@ -730,7 +735,7 @@ class RenderControl(BaseControl):
         elif thumb:
             tb = client.sf.createThumbnailStore()
             try:
-                tb.setPixelsId(long(pixid), ctx)
+                tb.setPixelsId(int(pixid), ctx)
                 tb.getThumbnailByLongestSide(rint(96), ctx)
             finally:
                 tb.close()

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -25,6 +25,7 @@ from builtins import range
 from builtins import object
 import sys
 import time
+import json
 import yaml
 
 from functools import wraps
@@ -497,7 +498,8 @@ class RenderControl(BaseControl):
                     self.ctx.die(
                         103,
                         "Output styles not supported for multiple images")
-                self.ctx.out(pydict_text_io.dump(ro.to_dict(), args.style))
+                self.ctx.out(json.dumps(
+                    ro.to_dict(), sort_keys=True, indent=4))
                 first = False
 
     @gateway_required

--- a/test/integration/clitest/cli.py
+++ b/test/integration/clitest/cli.py
@@ -20,6 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+from builtins import object
 import pytest
 
 import omero

--- a/test/integration/clitest/cli.py
+++ b/test/integration/clitest/cli.py
@@ -29,7 +29,7 @@ from omero.plugins.sessions import SessionsControl
 from omero.rtypes import rstring
 
 from omero.testlib import ITest
-from omero_ext.mox import Mox
+from mox3 import mox
 
 
 class AbstractCLITest(ITest):
@@ -41,7 +41,7 @@ class AbstractCLITest(ITest):
         cls.cli.register("sessions", SessionsControl, "TEST")
 
     def setup_mock(self):
-        self.mox = Mox()
+        self.mox = mox.Mox()
 
     def teardown_mock(self):
         self.mox.UnsetStubs()

--- a/test/integration/clitest/info.json
+++ b/test/integration/clitest/info.json
@@ -11,7 +11,7 @@
         },
         "2": {
             "active": true,
-            "color": "FF0000",
+            "color": "00FF00",
             "end": 255.0,
             "label": "1",
             "max": 255.0,
@@ -20,7 +20,7 @@
         },
         "3": {
             "active": true,
-            "color": "FF0000",
+            "color": "0000FF",
             "end": 255.0,
             "label": "2",
             "max": 255.0,
@@ -28,7 +28,7 @@
             "start": 0.0
         },
         "4": {
-            "active": true,
+            "active": false,
             "color": "FF0000",
             "end": 255.0,
             "label": "3",

--- a/test/integration/clitest/info.json
+++ b/test/integration/clitest/info.json
@@ -1,1 +1,44 @@
-{"channels": {"1": {"end": 255.0, "min": 0.0, "color": "FF0000", "max": 255.0, "label": "0", "start": 0.0, "active": true}, "2": {"end": 255.0, "min": 0.0, "color": "00FF00", "max": 255.0, "label": "1", "start": 0.0, "active": true}, "3": {"end": 255.0, "min": 0.0, "color": "0000FF", "max": 255.0, "label": "2", "start": 0.0, "active": true}, "4": {"end": 255.0, "min": 0.0, "color": "FF0000", "max": 255.0, "label": "3", "start": 0.0, "active": false}}, "greyscale": false, "version": 2, "z": 1, "t": 1}
+{
+    "channels": {
+        "1": {
+            "active": true,
+            "color": "FF0000",
+            "end": 255.0,
+            "label": "0",
+            "max": 255.0,
+            "min": 0.0,
+            "start": 0.0
+        },
+        "2": {
+            "active": true,
+            "color": "FF0000",
+            "end": 255.0,
+            "label": "1",
+            "max": 255.0,
+            "min": 0.0,
+            "start": 0.0
+        },
+        "3": {
+            "active": true,
+            "color": "FF0000",
+            "end": 255.0,
+            "label": "2",
+            "max": 255.0,
+            "min": 0.0,
+            "start": 0.0
+        },
+        "4": {
+            "active": true,
+            "color": "FF0000",
+            "end": 255.0,
+            "label": "3",
+            "max": 255.0,
+            "min": 0.0,
+            "start": 0.0
+        }
+    },
+    "greyscale": false,
+    "t": 1,
+    "version": 2,
+    "z": 1
+}

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -38,11 +38,6 @@ SUPPORTED = [
     "idonly", "imageid", "plateid", "screenid", "datasetid", "projectid"]
 
 
-@pytest.fixture(autouse=True)
-def setup(monkeypatch):
-    monkeypatch.setenv("OMERODIR", "/opt/omero/server/OMERO.server")
-
-
 class TestRender(CLITest):
 
     def setup_method(self, method):

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -38,6 +38,11 @@ SUPPORTED = [
     "idonly", "imageid", "plateid", "screenid", "datasetid", "projectid"]
 
 
+@pytest.fixture(autouse=True)
+def setup(monkeypatch):
+    monkeypatch.setenv("OMERODIR", "/opt/omero/server/OMERO.server")
+
+
 class TestRender(CLITest):
 
     def setup_method(self, method):

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -19,6 +19,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from __future__ import division
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import json
 import pytest
 
@@ -161,7 +165,7 @@ class TestRender(CLITest):
             d['t'] = t
         if z is not None:
             d['z'] = z
-        for k in xrange(sizec, 4):
+        for k in range(sizec, 4):
             del channels[k + 1]
         d['version'] = version
         return d
@@ -179,7 +183,7 @@ class TestRender(CLITest):
             # the RenderingEngine but then Nones are returned later.
             channels = img.getChannels()
             assert len(channels) == len(rdef['channels'])
-            for c in xrange(len(channels)):
+            for c in range(len(channels)):
                 self.assert_channel_rdef(
                     channels[c], rdef['channels'][c + 1],
                     version=rdef['version'])
@@ -201,7 +205,7 @@ class TestRender(CLITest):
                 assert img.getDefaultZ() == rdef.get('z') - 1
             else:
                 # If not set, default Z plane is the middle one
-                assert img.getDefaultZ() == (int)(img.getSizeZ() / 2)
+                assert img.getDefaultZ() == (int)(old_div(img.getSizeZ(), 2))
 
     def assert_channel_rdef(self, channel, rdef, version=2):
         assert channel.getLabel() == rdef['label']


### PR DESCRIPTION
This PR updates `omero-cli-render` to be Python 3 compatible.

- run `futurize` on the code
- declare `omero-py`, `future` as dependencies and switch to `mox3`

Travis should test the installation of the plugin as well as run the integration tests against the current Python 3 `omero-test-infra` environment.


Proposed tag `0.5.dev1`