### PR TITLE
Add integration test for the info subcommand with plain style

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -301,8 +301,9 @@ class RenderObject(object):
         self.defaultT = image._re.getDefaultT()
 
     def __str__(self):
-        sb = "rdefv1: model=%s, z=%s, t=%s\n" % (
-            self.model, self.defaultZ, self.defaultT)
+        """Return a string representation of the render object"""
+        sb = "rdefv%s: model=%s, z=%s, t=%s\n" % (
+            SPEC_VERSION, self.model, self.defaultZ, self.defaultT)
         sb += "tiles: %s\n" % (self.tiles,)
         for idx, ch in enumerate(self.channels):
             sb += "ch%s: %s\n" % (idx, ch)

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -488,7 +488,7 @@ class RenderControl(BaseControl):
         for img in self.render_images(self.gateway, args.object, batch=1):
             ro = RenderObject(img)
             if args.style == 'plain':
-                self.ctx.out(ro)
+                self.ctx.out(str(ro))
             elif args.style == 'yaml':
                 self.ctx.out(yaml.dump(ro.to_dict(), explicit_start=True,
                              width=80, indent=4,

--- a/test/integration/clitest/info.plain
+++ b/test/integration/clitest/info.plain
@@ -1,4 +1,4 @@
-rdefv1: model=color, z=0, t=0
+rdefv2: model=color, z=0, t=0
 tiles: False
 ch0: active=True,color=FF0000,label=0,min=0.0,start=0.0,end=255.0,max=255.0
 ch1: active=True,color=00FF00,label=1,min=0.0,start=0.0,end=255.0,max=255.0

--- a/test/integration/clitest/info.plain
+++ b/test/integration/clitest/info.plain
@@ -1,0 +1,7 @@
+rdefv1: model=color, z=0, t=0
+tiles: False
+ch0: active=True,color=FF0000,label=0,min=0.0,start=0.0,end=255.0,max=255.0
+ch1: active=True,color=00FF00,label=1,min=0.0,start=0.0,end=255.0,max=255.0
+ch2: active=True,color=0000FF,label=2,min=0.0,start=0.0,end=255.0,max=255.0
+ch3: active=False,color=FF0000,label=3,min=0.0,start=0.0,end=255.0,max=255.0
+

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -246,7 +246,7 @@ class TestRender(CLITest):
         self.args += ["info", target]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.parametrize('style', ['json', 'yaml'])
+    @pytest.mark.parametrize('style', ['plain', 'json', 'yaml'])
     def test_info_style(self, style, capsys):
         self.create_image()
         target = self.imageid
@@ -256,9 +256,11 @@ class TestRender(CLITest):
         out, err = capsys.readouterr()
 
         dir_name = os.path.dirname(os.path.abspath(__file__))
-        expected_file = {'json': 'info.json', 'yaml': 'info.yml'}
+        expected_file = {
+            'plain': 'info.plain', 'json': 'info.json', 'yaml': 'info.yml'}
         with open(os.path.join(dir_name, expected_file[style]), 'r') as f:
             assert out == f.read()
+        assert 'Error printing text' not in err
 
     @pytest.mark.parametrize('target_name', sorted(SUPPORTED))
     def test_copy(self, target_name, tmpdir):


### PR DESCRIPTION
See https://github.com/ome/omero-cli-render/pull/31#issuecomment-555949322

- 49b8cad adds a new integration test covering the `--style plain` output of the `info` subcommand including some assertion that there is no printing error in the stderr
- ff001f6 fixes the printing error