### PR TITLE
Parallelize the set command

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -589,7 +589,8 @@ class RenderControl(BaseControl):
                 def_t = None
         return (def_z, def_t)
 
-    def _set_rend(self, args, data, img, cindices, greyscale, rangelist, colorlist):
+    def _set_rend(self, args, data, img, cindices, greyscale, rangelist,
+                  colorlist):
         """Set the renderings settings for one image"""
         (def_z, def_t) = self._read_default_planes(
             img, data, ignore_errors=args.ignore_errors)
@@ -689,22 +690,28 @@ class RenderControl(BaseControl):
         iids = []
 
         if args.batch > 1:
-            for img_batch in self.load_images(self.gateway, args.object, batch=args.batch):
+            for img_batch in self.load_images(self.gateway, args.object,
+                                              batch=args.batch):
                 with concurrent.futures.ThreadPoolExecutor() as executor:
-                    future_image = { executor.submit(self._set_rend, args, data,
-                                                     img, cindices, greyscale, rangelist,
-                                                     colorlist): img for img in img_batch}
-                    for future in concurrent.futures.as_completed(future_image):
+                    future_image = {executor.submit(self._set_rend, args,
+                                                    data, img, cindices,
+                                                    greyscale, rangelist,
+                                                    colorlist):
+                                    img for img in img_batch}
+                    for future in concurrent.futures.as_completed(
+                            future_image):
                         img = future_image[future]
                         try:
                             iid = future.result()
                             iids.append(iid)
                         except Exception as exc:
-                            print('%d generated an exception: %s' % (img.id, exc))
+                            print('%d generated an exception: %s' % (img.id,
+                                                                     exc))
 
         else:
             for img in self.load_images(self.gateway, args.object, batch=1):
-                iid = self._set_rend(args, data, img, cindices, greyscale, rangelist, colorlist)
+                iid = self._set_rend(args, data, img, cindices, greyscale,
+                                     rangelist, colorlist)
                 iids.append(iid)
 
         if not iids:

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -398,7 +398,7 @@ class RenderControl(BaseControl):
                      "rendering settings")
 
         set_cmd.add_argument(
-            "--batch", type=int,
+            "--batch", type=int, default=1,
             help="Batch size to process simultaneously"
         )
 
@@ -636,11 +636,6 @@ class RenderControl(BaseControl):
     @gateway_required
     def set(self, args):
         """ Implements the 'set' command """
-        if args.batch:
-            batch = args.batch
-        else:
-            batch = 1
-
         newchannels = {}
         data = pydict_text_io.load(
             args.channels, session=self.client.getSession())
@@ -693,8 +688,8 @@ class RenderControl(BaseControl):
 
         iids = []
 
-        if batch > 1:
-            for img_batch in self.load_images(self.gateway, args.object, batch=batch):
+        if args.batch > 1:
+            for img_batch in self.load_images(self.gateway, args.object, batch=args.batch):
                 with concurrent.futures.ThreadPoolExecutor() as executor:
                     future_image = { executor.submit(self._set_rend, args, data,
                                                      img, cindices, greyscale, rangelist,


### PR DESCRIPTION
Adds a `--batch` option to the set command.

Test:
Get rendering settings from an image:
```
./omero -s merge-ci-devspace.openmicroscopy.org render info --style yaml Image:123 >> rend.yml
```
Then apply it to a whole Dataset, Project or whatever (with compatible images).

Example:
```
time ./omero -s merge-ci-devspace.openmicroscopy.org render set Dataset:3192 rend.yml
2.11s user 0.68s system 5% cpu 49.045 total

time ./omero -s merge-ci-devspace.openmicroscopy.org render set --batch 10 Dataset:3192 rend.yml
1.84s user 0.48s system 33% cpu 6.857 total
```

Needs https://github.com/ome/omero-py/pull/129 to work.
