### PR TITLE
render set: helper refactoring

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -669,8 +669,9 @@ class RenderControl(BaseControl):
             img.set_active_channels(
                 cindices, windows=rangelist, colors=colourlist)
 
-            if data.get('greyscale', None) is not None:
-                self.ctx.dbg('greyscale=%s' % data['greyscale'])
+            greyscale = data.get('greyscale', None)
+            if greyscale is not None:
+                self.ctx.dbg('greyscale=%s' % greyscale)
                 if greyscale:
                     img.setGreyscaleRenderingModel()
                 else:

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -644,14 +644,16 @@ class RenderControl(BaseControl):
         """ Implements the 'set' command """
         data = self._load_rendering_settings(
             args.channels, session=self.client.getSession())
+        (namedict, cindices, rangelist, colourlist) = self._read_channels(
+            data)
+        greyscale = data.get('greyscale', None)
+        if greyscale is not None:
+            self.ctx.dbg('greyscale=%s' % greyscale)
 
         iids = []
         for img in self.render_images(self.gateway, args.object, batch=1):
             iids.append(img.id)
 
-            # Extract settings from dictionary
-            (namedict, cindices, rangelist, colourlist) = self._read_channels(
-                data)
             (def_z, def_t) = self._read_default_planes(
                 img, data, ignore_errors=args.ignore_errors)
 
@@ -669,9 +671,7 @@ class RenderControl(BaseControl):
             img.set_active_channels(
                 cindices, windows=rangelist, colors=colourlist)
 
-            greyscale = data.get('greyscale', None)
             if greyscale is not None:
-                self.ctx.dbg('greyscale=%s' % greyscale)
                 if greyscale:
                     img.setGreyscaleRenderingModel()
                 else:

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -590,7 +590,7 @@ class RenderControl(BaseControl):
             data = pydict_text_io.load(source, session=session)
         except Exception as e:
             self.ctx.dbg(e)
-            self.ctx.die(104, "Could not read %s" % source)
+            self.ctx.die(103, "Could not read %s" % source)
 
         if 'channels' not in data:
             self.ctx.die(104, "ERROR: No channels found in %s" % source)

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -584,10 +584,9 @@ class RenderControl(BaseControl):
                 def_t = None
         return (def_z, def_t)
 
-    def _load_rendering_settings(self, source):
+    def _load_rendering_settings(self, source, session=None):
         """Load a rendering dictionary from a source (file or object)"""
-        data = pydict_text_io.load(
-            source, session=self.client.getSession())
+        data = pydict_text_io.load(source, session=session)
         if 'channels' not in data:
             self.ctx.die(104, "ERROR: No channels found in %s" % source)
 
@@ -638,7 +637,8 @@ class RenderControl(BaseControl):
     @gateway_required
     def set(self, args):
         """ Implements the 'set' command """
-        data = self._load_rendering_settings(args.channels)
+        data = self._load_rendering_settings(
+            args.channels, session=self.client.getSession())
 
         iids = []
         for img in self.render_images(self.gateway, args.object, batch=1):

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -618,7 +618,7 @@ class RenderControl(BaseControl):
             try:
                 cobj = ChannelObject(chdict, version)
                 newchannels[cindex] = cobj
-                print('%d:%s' % (cindex, cobj))
+                self.ctx.dbg('%d:%s' % (cindex, cobj))
             except Exception as e:
                 self.ctx.err('ERROR: %s' % e)
                 self.ctx.die(
@@ -651,6 +651,8 @@ class RenderControl(BaseControl):
 
             # Extract settings from dictionary
             greyscale = data.get('greyscale', None)
+            if greyscale is not None:
+                self.ctx.dbg('greyscale=%s' % data['greyscale'])
             (namedict, cindices, rangelist, colourlist) = self._read_channels(
                 data)
             (def_z, def_t) = self._read_default_planes(

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -586,7 +586,12 @@ class RenderControl(BaseControl):
 
     def _load_rendering_settings(self, source, session=None):
         """Load a rendering dictionary from a source (file or object)"""
-        data = pydict_text_io.load(source, session=session)
+        try:
+            data = pydict_text_io.load(source, session=session)
+        except Exception as e:
+            self.ctx.dbg(e)
+            self.ctx.die(104, "Could not read %s" % source)
+
         if 'channels' not in data:
             self.ctx.die(104, "ERROR: No channels found in %s" % source)
 

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -650,9 +650,6 @@ class RenderControl(BaseControl):
             iids.append(img.id)
 
             # Extract settings from dictionary
-            greyscale = data.get('greyscale', None)
-            if greyscale is not None:
-                self.ctx.dbg('greyscale=%s' % data['greyscale'])
             (namedict, cindices, rangelist, colourlist) = self._read_channels(
                 data)
             (def_z, def_t) = self._read_default_planes(
@@ -671,7 +668,9 @@ class RenderControl(BaseControl):
 
             img.set_active_channels(
                 cindices, windows=rangelist, colors=colourlist)
-            if greyscale is not None:
+
+            if data.get('greyscale', None) is not None:
+                self.ctx.dbg('greyscale=%s' % data['greyscale'])
                 if greyscale:
                     img.setGreyscaleRenderingModel()
                 else:

--- a/test/unit/test_set.py
+++ b/test/unit/test_set.py
@@ -63,3 +63,23 @@ class TestLoadRenderingSettings:
         with pytest.raises(NonZeroReturnCode) as e:
             self.render._load_rendering_settings(f)
         assert e.value.rv == 124
+
+
+class TestReadChannels:
+    def setup_method(self):
+        self.cli = CLI()
+        self.cli.register("render", RenderControl, "TEST")
+        self.render = self.cli.controls['render']
+
+    def test_non_integer_channel(self):
+        d = {'channels': {'GFP': {'label': 'foo'}}}
+        with pytest.raises(NonZeroReturnCode) as e:
+            self.render._read_channels(d)
+        assert e.value.rv == 105
+
+    @pytest.mark.parametrize('key', ['min', 'max', 'start', 'end'])
+    def test_float_keys(self, key):
+        d = {'channels': {1: {key: 'foo'}}}
+        with pytest.raises(NonZeroReturnCode) as e:
+            self.render._read_channels(d)
+        assert e.value.rv == 105

--- a/test/unit/test_set.py
+++ b/test/unit/test_set.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2019 University of Dundee All Rights Reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+from omero.cli import CLI
+from omero_cli_render import RenderControl
+
+import pytest
+
+
+class TestLoadRenderingSettings:
+    def setup_method(self):
+        self.cli = CLI()
+        self.cli.register("render", RenderControl, "TEST")
+        self.render = self.cli.controls['render']
+
+    def test_none(self):
+        with pytest.raises(Exception):
+            self.render._load_rendering_settings(None)

--- a/test/unit/test_set.py
+++ b/test/unit/test_set.py
@@ -20,10 +20,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
-from omero.cli import CLI
+from omero.cli import CLI, NonZeroReturnCode
 from omero_cli_render import RenderControl
 
 import pytest
+import uuid
 
 
 class TestLoadRenderingSettings:
@@ -33,5 +34,9 @@ class TestLoadRenderingSettings:
         self.render = self.cli.controls['render']
 
     def test_none(self):
-        with pytest.raises(Exception):
+        with pytest.raises(NonZeroReturnCode):
             self.render._load_rendering_settings(None)
+
+    def test_non_existing_file(self, tmpdir):
+        with pytest.raises(NonZeroReturnCode):
+            self.render._load_rendering_settings(str(uuid.uuid4()) + '.yml')


### PR DESCRIPTION
While working on a feature allowing to process multiple images with multiple rendering settings, I found it useful to refactor the logic of the `render set` command dealing with loading and parsing rendering settings from a source (object or file on disk).

The changes included in this PR should not changing behavior, include some cleanup (`print` ->`debug`) as well as unit tests starting to cover some of the individual functionalities