### PR TITLE
Fix reactivate channels

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -664,7 +664,8 @@ class RenderControl(BaseControl):
                 # Need to reset ALL active channels after set_active_channels()
                 imgchannels = img.getChannels()
                 for ci, ch in enumerate(imgchannels, 1):
-                    if -ci not in cindices and ch.isActive():
+                    if (-ci not in cindices and ch.isActive()) \
+                            or ci in cindices:
                         active_channels.append(ci)
 
             img.set_active_channels(

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -657,16 +657,15 @@ class RenderControl(BaseControl):
             (def_z, def_t) = self._read_default_planes(
                 img, data, ignore_errors=args.ignore_errors)
 
-            reactivatechannels = []
+            active_channels = []
             if not args.disable:
                 # Calling set_active_channels will disable channels which
-                # are not specified, have to keep track of them and
-                # re-activate them later again
+                # are not specified.
+                # Need to reset ALL active channels after set_active_channels()
                 imgchannels = img.getChannels()
                 for ci, ch in enumerate(imgchannels, 1):
-                    if ci not in cindices and -ci not in cindices\
-                            and ch.isActive():
-                        reactivatechannels.append(ci)
+                    if -ci not in cindices and ch.isActive():
+                        active_channels.append(ci)
 
             img.set_active_channels(
                 cindices, windows=rangelist, colors=colourlist)
@@ -677,8 +676,9 @@ class RenderControl(BaseControl):
                 else:
                     img.setColorRenderingModel()
 
-            if len(reactivatechannels) > 0:
-                img.set_active_channels(reactivatechannels)
+            # Re-activate any un-listed channels
+            if len(active_channels) > 0:
+                img.set_active_channels(active_channels)
 
             if def_z:
                 img.setDefaultZ(def_z - 1)


### PR DESCRIPTION
Previously, ```img.set_active_channels(reactivatechannels)``` was turning OFF the channels
that were active and edited in the previous set_active_channels() call.

To test, find an Image with 3 Channels, all Active.
Run:
```
$ omero render set Image:1 settings.yml
```
with less than 3 Channels specified, e.g.

settings.yml
```yaml
---
channels:
    1:
        active: true
        start: 0
        end: 255
greyscale: false
version: 2
```

This should only edit the first Channel. All 3 channels should stay Active.