### PR TITLE
Rename channel

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -146,7 +146,7 @@ TEST_RENAME = """Rename channels
 
     Examples:
     omero render rename Image:1 channel_names.json
-    omero render rename Dataset:1 '{1: "First Channel", 2: "Second Channel"}'
+    omero render rename Dataset:1 '{"1":"First Channel", "2":"Second Channel"}'
 """
 
 

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -349,3 +349,21 @@ class TestRender(CLITest):
         self.args += ["--ignore-errors"]
         self.cli.invoke(self.args, strict=True)
         self.assert_target_rdef(self.idonly, rd)
+
+    def test_rename(self, tmpdir):
+        self.create_image(sizec=3)
+        gw = BlitzGateway(client_obj=self.client)
+        image = gw.getObject('Image', self.idonly)
+        ch3_name = image.getChannels()[2].getName()
+
+        ch = {"1": "First", "2": "Second"}
+        chfile = tmpdir.join('channel_names.json')
+        chfile.write(json.dumps(ch))
+        self.args += ["rename", self.idonly, str(chfile)]
+        self.cli.invoke(self.args, strict=True)
+
+        image = gw.getObject('Image', self.idonly)
+        channels = image.getChannels()
+        assert channels[0].getName() == "First"
+        assert channels[0].getName() == "Second"
+        assert channels[0].getName() == ch3_name


### PR DESCRIPTION
Adds a 'command' to change channel names, without going through all the rendering settings shebang. There was already a method for this called `update_channel_names` which was never used anywhere apparently.

--exclude for now as this will conflict with @will-moore 's PR. Going to rebase the PR once the other one has been merged.
