### PR TITLE
Set rendering settings for inactive channels

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -670,7 +670,8 @@ class RenderControl(BaseControl):
                         active_channels.append(ci)
 
             img.set_active_channels(
-                cindices, windows=rangelist, colors=colourlist)
+                cindices, windows=rangelist, colors=colourlist,
+                set_inactive=True)
 
             if greyscale is not None:
                 if greyscale:

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -378,3 +378,16 @@ class TestRender(CLITest):
         image = gw.getObject('Image', self.idonly)
         for idx, ch in enumerate(image.getChannels()):
             assert ch.isActive() == (idx == 0)
+
+    def test_set_inactive(self, tmpdir):
+        """Test rendering settings  """
+        self.create_image()
+        rd = self.get_render_def()
+        rd['channels'][1]['active'] = False
+        rd['channels'][4]['active'] = False
+        rdfile = tmpdir.join('render-test-setinactive.json')
+        rdfile.write(json.dumps(rd))
+
+        self.args += ["set", self.idonly, str(rdfile)]
+        self.cli.invoke(self.args, strict=True)
+        self.assert_target_rdef(self.idonly, rd)


### PR DESCRIPTION
This PR attempts to fix the behavior of the current render plugin when a YML/JSON file contains rendering settings (color, start/end window) for both active and inactive channels. In the current scenario, the rendering settings for the inactive channels are silently ignored. fc9cee4  contains a failing test capturing this behavior.

This issue was the primary motivation behind the `omero.gateway` API introduced in https://github.com/ome/openmicroscopy/pull/5955. With this change, rendering settings should be applied independently of the active state of the channel if specified via the configuration file.

Opening this as a behavior change of the plugin as I consider the current implementation as faulty and inconsistent with the fact channel names are set unconditionally. If backward compatibility and/or support for the previous behavior is valuable, this could be introduced as a `--{ignore,set}-inactive` option for the `set` command.