### PR TITLE
Version detection fix

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -172,7 +172,10 @@ def _getversion(dictionary):
             if 'min' in chdict or 'max' in chdict:
                 return 1
     else:
-        return dictionary['version']
+        v = dictionary['version']
+        if not isinstance(v, int) or v < 1 or v > SPEC_VERSION:
+            return 0
+        return v
     return SPEC_VERSION
 
 

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -173,7 +173,7 @@ def _getversion(dictionary):
                 return 1
     else:
         return dictionary['version']
-    return 0
+    return SPEC_VERSION
 
 
 class ChannelObject(object):

--- a/test/unit/test_set.py
+++ b/test/unit/test_set.py
@@ -57,12 +57,11 @@ class TestLoadRenderingSettings:
             self.render._load_rendering_settings(f)
         assert e.value.rv == 104
 
-    def test_bad_version(self, tmpdir):
+    def test_missing_version_pass(self, tmpdir):
         d = {'channels': {1: {'label': 'foo'}}}
         f = write_yaml(d, tmpdir)
-        with pytest.raises(NonZeroReturnCode) as e:
-            self.render._load_rendering_settings(f)
-        assert e.value.rv == 124
+        data = self.render._load_rendering_settings(f)
+        assert data == d
 
 
 class TestReadChannels:

--- a/test/unit/test_set.py
+++ b/test/unit/test_set.py
@@ -21,7 +21,7 @@
 
 
 from omero.cli import CLI, NonZeroReturnCode
-from omero_cli_render import RenderControl
+from omero_cli_render import RenderControl, SPEC_VERSION, _getversion
 
 import pytest
 import uuid
@@ -62,6 +62,47 @@ class TestLoadRenderingSettings:
         f = write_yaml(d, tmpdir)
         data = self.render._load_rendering_settings(f)
         assert data == d
+        assert _getversion(d) == SPEC_VERSION
+
+    @pytest.mark.parametrize('key1', ['start', 'end'])
+    @pytest.mark.parametrize('key2', ['min', 'max'])
+    def test_missing_version_fail(self, tmpdir, key1, key2):
+        d = {'channels': {1: {key1: 100, key2: 200}}}
+        f = write_yaml(d, tmpdir)
+        with pytest.raises(NonZeroReturnCode) as e:
+            self.render._load_rendering_settings(f)
+        assert e.value.rv == 124
+
+    @pytest.mark.parametrize('key', ['start', 'end'])
+    def test_version_2(self, tmpdir, key):
+        d = {'channels': {1: {key: 100, 'label': 'foo'}}}
+        f = write_yaml(d, tmpdir)
+        data = self.render._load_rendering_settings(f)
+        assert data == d
+        assert _getversion(d) == 2
+
+    @pytest.mark.parametrize('key', ['min', 'max'])
+    def test_version_1(self, tmpdir, key):
+        d = {'channels': {1: {key: 100, 'label': 'foo'}}}
+        f = write_yaml(d, tmpdir)
+        data = self.render._load_rendering_settings(f)
+        assert data == d
+        assert _getversion(d) == 1
+
+    @pytest.mark.parametrize('version', [1, 2])
+    def test_version_detection(self, tmpdir, version):
+        d = {'version': version, 'channels': {1: {'label': 'foo'}}}
+        f = write_yaml(d, tmpdir)
+        data = self.render._load_rendering_settings(f)
+        assert data == d
+        assert _getversion(d) == version
+
+    def test_version_fail(self, tmpdir):
+        d = {'version': 0, 'channels': {1: {'label': 'foo'}}}
+        f = write_yaml(d, tmpdir)
+        with pytest.raises(NonZeroReturnCode) as e:
+            self.render._load_rendering_settings(f)
+        assert e.value.rv == 124
 
 
 class TestReadChannels:


### PR DESCRIPTION
Reported by @jburel. In the absence of an explicit `version` key in the rendering file, the detection logic in `_getversion()` is currently checking the presence of `start/end` vs `min/max` keys (as the semantics of these has changed since version 1 and 2) and unconditionally returning `0` (undefined version) in absence of any of these keys. This means a simple rendering file as the following is currently detected as invalid:

```
---
channels:
  1:
    label: 'DNA' 
```

ab081ac fixes this issue by returning the version of the latest specification version (`2`)in this case.  28a10df also increases the type and the range of supported versions when the `version` argument is present. Several unit tests have been added that should test various YML files and the plugin expectation when loading these.

Travis unit and integration tests should keep passing. Additionally, a simple test should be run with a minimal YML file like the one mentioned above. `omero render set` should fail without this PR and pass with this PR included.

Proposed relase: 0.6.1