### PR TITLE
Add dependency on omero-py 5.8+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,9 +118,7 @@ setup(
     author_email='ome-devel@lists.openmicroscopy.org.uk',
     license='GPL-2.0+',
     install_requires=[
-        'PyYAML',
-        'omero-py>=5.6.0',
-        'future'
+        'omero-py>=5.8.0',
         ],
     python_requires='>=3',
     url='%s' % url,


### PR DESCRIPTION
The primary motivation is to get rid of the `DeprecationWarning` thrown on every invocation of `omero render set Object:id file.yml` fixed in https://github.com/ome/omero-py/pull/228/commits/dcde6b23ea99e28310dc89dc0c37d93eef46ab22.

Also remove unnecessary PyYAML dependency which should be declared transitively

Proposed tag `0.6.2`