### PR TITLE
Make sure RE is closed

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -491,21 +491,27 @@ class RenderControl(BaseControl):
         """ Implements the 'info' command """
         first = True
         for img in self.render_images(self.gateway, args.object, batch=1):
-            ro = RenderObject(img)
-            if args.style == 'plain':
-                self.ctx.out(str(ro))
-            elif args.style == 'yaml':
-                self.ctx.out(yaml.dump(ro.to_dict(), explicit_start=True,
-                             width=80, indent=4,
-                             default_flow_style=False).rstrip())
-            else:
-                if not first:
-                    self.ctx.die(
-                        103,
-                        "Output styles not supported for multiple images")
-                self.ctx.out(json.dumps(
-                    ro.to_dict(), sort_keys=True, indent=4))
-                first = False
+            try:
+                ro = RenderObject(img)
+                if args.style == 'plain':
+                    self.ctx.out(str(ro))
+                elif args.style == 'yaml':
+                    self.ctx.out(yaml.dump(ro.to_dict(), explicit_start=True,
+                                           width=80, indent=4,
+                                           default_flow_style=False).rstrip())
+                else:
+                    if not first:
+                        self.ctx.die(
+                            103,
+                            "Output styles not supported for multiple images")
+                    self.ctx.out(json.dumps(
+                        ro.to_dict(), sort_keys=True, indent=4))
+                    first = False
+            except Exception as e:
+                self.ctx.err('ERROR: %s' % e)
+            finally:
+                img._closeRE()
+
 
     @gateway_required
     def copy(self, args):

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -512,7 +512,6 @@ class RenderControl(BaseControl):
             finally:
                 img._closeRE()
 
-
     @gateway_required
     def copy(self, args):
         """ Implements the 'copy' command """
@@ -547,10 +546,10 @@ class RenderControl(BaseControl):
             self._update_channel_names(self, iids, namedict)
 
     def _update_channel_names(self, gateway, iids, namedict):
-            counts = gateway.setChannelNames("Image", iids, namedict)
-            if counts:
-                self.ctx.dbg("Updated channel names for %d/%d images" % (
-                    counts['updateCount'], counts['imageCount']))
+        counts = gateway.setChannelNames("Image", iids, namedict)
+        if counts:
+            self.ctx.dbg("Updated channel names for %d/%d images" % (
+                counts['updateCount'], counts['imageCount']))
 
     def _generate_thumbs(self, images):
         for img in images:


### PR DESCRIPTION
The `info` command creates a `RenderObject` which loads a RenderingEngine but doesn't close it. When you run it on a large Plate you soon hit an OutOfMemory exception. This PR closes the RenderingEngine again. 

~~The PR also adds a `thumb` command which generates rendering settings (if there aren't any yet) and creates the thumbnails. Without it one has to run first `render info` and then `test --thumb`.~~