### PR TITLE
Support min/max to update StatsInfo

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -98,8 +98,8 @@ SET_HELP = """Set rendering settings
         label: <string>     Channel name
         start: <float>      Start of rendering window, optional (needs end)
         end: <float>        End of rendering window, optional (needs start)
-        min: <float>        Min pixel intensity, optional (needs max if unset)
-        max: <float>        Max pixel intensity, optional (needs min if unset)
+        min: <float>        Minimum pixel intensity, optional (needs max)
+        max: <float>        Maximum pixel intensity, optional (needs min)
       <int>:
         ...
     greyscale: <bool>               Greyscale rendering, optional
@@ -126,9 +126,12 @@ SET_HELP = """Set rendering settings
     # Omitted fields will keep their current values.
     # Omitted channels will not be disabled unless --disable is used.
     # If the file specifies to turn off a channel (active: False) then the
-    # other settings like min, max, and color which might be specified for
+    # other settings like start, end, and color which might be specified for
     # that channel in the same file will be ignored, however the channel
     # name (label) is still taken into account.
+    # If min and max have not been set on the channel (no StatsInfo on the
+    # channel) then you must set both. If max and min already set, each can
+    # be updated individually.
 """
 
 TEST_HELP = """Test that underlying pixel data is available

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -98,8 +98,8 @@ SET_HELP = """Set rendering settings
         label: <string>     Channel name
         start: <float>      Start of rendering window, optional (needs end)
         end: <float>        End of rendering window, optional (needs start)
-        min: <float>        Minimum pixel value intensity, optional
-        max: <float>        Maximum pixel value intensity, optional
+        min: <float>        Min pixel intensity, optional (needs max if unset)
+        max: <float>        Max pixel intensity, optional (needs min if unset)
       <int>:
         ...
     greyscale: <bool>               Greyscale rendering, optional


### PR DESCRIPTION
This adds support for setting `min` and `max`.
E.g:

```
---
channels:
    1:
        active: true
        end: 2000.0
        start: 150.0
        min: 10
        max: 3000
greyscale: false
version: 2
```

Both `min` and `max` are optional and don't depend on each other.
To test:

 - `omero render set Image:1 settings.yml`
 - Then Refresh right panel in webclient, or refresh iviewer and click Min/Max to set rendering settings to the new min/max values.

cc @pwalczysko 

Based on example code from:
https://github.com/ome/omero-scripts/pull/103/files#diff-70c904f67c4f0348841edf1ebdac7c32d8914ab87ac05a0a8f9948d47a8b94d7R195