### PR TITLE
Remove mox3 from the test requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
     keywords=['OMERO.CLI', 'plugin'],
     cmdclass={'test': PyTest},
     tests_require=[
-        'omero-py>=5.17.0',
+        'omero-py>=5.18.0',
         'pytest',
         'restview'],
 )

--- a/setup.py
+++ b/setup.py
@@ -128,5 +128,8 @@ setup(
     download_url='%s/v%s.tar.gz' % (url, version),
     keywords=['OMERO.CLI', 'plugin'],
     cmdclass={'test': PyTest},
-    tests_require=['pytest', 'restview', 'mox3'],
+    tests_require=[
+        'omero-py>=5.17.0',
+        'pytest',
+        'restview'],
 )

--- a/test/integration/clitest/cli.py
+++ b/test/integration/clitest/cli.py
@@ -24,28 +24,8 @@ from builtins import object
 import pytest
 
 import omero
-from omero.cli import CLI
-from omero.plugins.sessions import SessionsControl
 from omero.rtypes import rstring
-
-from omero.testlib import ITest
-from mox3 import mox
-
-
-class AbstractCLITest(ITest):
-
-    @classmethod
-    def setup_class(cls):
-        super(AbstractCLITest, cls).setup_class()
-        cls.cli = CLI()
-        cls.cli.register("sessions", SessionsControl, "TEST")
-
-    def setup_mock(self):
-        self.mox = mox.Mox()
-
-    def teardown_mock(self):
-        self.mox.UnsetStubs()
-        self.mox.VerifyAll()
+from omero.testlib.cli import AbstractCLITest
 
 
 class CLITest(AbstractCLITest):


### PR DESCRIPTION
See https://github.com/ome/omero-py/pull/385

- Update tests requirements to require OMERO.py 5.17.0 which deprecates the usage of mox3 for running integration tests
- Consume omero.testlib.cli.AbstractCLITest