### PR TITLE
Add export and impo(rt) commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ omero-cli-render-*
 .*un~
 *.pyc
 .omero
+*.iml
+.idea
+

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -150,6 +150,8 @@ TEST_HELP = """Test that underlying pixel data is available
 
 EXPORT_HELP = """Export rendering settings as yaml files
 
+Note: Does not for Screen/Plate yet!
+
 Examples:
     Export one yaml file for each Dataset in a Project (first image)
     (into ./DATASET_NAME/IMAGE_NAME.yml):
@@ -161,6 +163,8 @@ Examples:
 """
 
 IMPO_HELP = """Import rendering settings as yaml files
+
+Note: Does not for Screen/Plate yet!
 
 Yaml files have to be in directories with the name of the dataset,
 i.e. ./DATASET_NAME/IMAGE_NAME.yml !

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -28,14 +28,14 @@ from functools import wraps
 from omero.cli import BaseControl
 from omero.cli import CLI
 from omero.cli import ProxyStringType
-from omero.gateway import BlitzGateway
+from omero.gateway import BlitzGateway, DatasetWrapper
 from omero.model import Image
 from omero.model import Plate
 from omero.model import Screen
 from omero.model import Dataset
 from omero.model import Project
 from omero.model import StatsInfoI
-from omero.rtypes import rint, rdouble
+from omero.rtypes import rint, rdouble, rstring, rlong
 from omero.util import pydict_text_io
 
 from omero import UnloadedEntityException
@@ -370,11 +370,13 @@ class RenderControl(BaseControl):
         set_cmd = parser.add(sub, self.set, SET_HELP)
         edit = parser.add(sub, self.edit, EDIT_HELP)
         test = parser.add(sub, self.test, TEST_HELP)
+        export = parser.add(sub, self.export, "Export rendering settings as yaml files")
+        impo = parser.add(sub, self.impo, "Import rendering settings from yaml files")
 
         render_type = ProxyStringType("Image")
         src_help = ("Rendering settings source")
 
-        for x in (get, info, copy, test):
+        for x in (get, info, copy, test, export):
             x.add_argument("object", type=render_type, help=src_help)
 
         tgt_help = ("Objects to apply the rendering settings to")
@@ -382,7 +384,7 @@ class RenderControl(BaseControl):
             x.add_argument("object", type=render_type, help=tgt_help,
                            nargs="+")
 
-        for x in (copy, set_cmd, edit):
+        for x in (copy, set_cmd, edit, impo):
             x.add_argument(
                 "--skipthumbs", help="Do not regenerate thumbnails "
                                      "immediately", action="store_true")
@@ -399,7 +401,7 @@ class RenderControl(BaseControl):
         copy.add_argument("target", type=render_type, help=tgt_help,
                           nargs="+")
 
-        for x in (set_cmd, edit):
+        for x in (set_cmd, edit, impo):
             x.add_argument(
                 "--disable", help="Disable non specified channels ",
                 action="store_true")
@@ -420,6 +422,14 @@ class RenderControl(BaseControl):
             "--thumb", action="store_true",
             help="If underlying pixel data available test thumbnail retrieval"
         )
+
+        export.add_argument("--sep", default="|", help="Separator character (default: |)")
+        export.add_argument("--traverse", action="store_true", help="Export settings for all images of a dataset (default: just first one)")
+
+        impo.add_argument("--sep", default="|", help="Separator character (default: |)")
+        impo.add_argument("--dataset", action="store_true", help="Rendering settings should be applied to the whole dataset")
+        impo.add_argument("--spw", action="store_true", help="If target is Screen/Plate/Well (NOT SUPPORTED YET)")
+
 
     def _lookup(self, gateway, type, oid):
         # TODO: move _lookup to a _configure type
@@ -529,6 +539,127 @@ class RenderControl(BaseControl):
                 self.ctx.err('ERROR: %s' % e)
             finally:
                 img._closeRE()
+
+
+    def _get_datasets_for_image(self, gateway, img_id):
+        """
+        Get all datasets an image is part of.
+        :param gateway: Ref to gateway
+        :param img: The image
+        :return: The datasets
+        """
+        query = "select i from Image i join fetch i.datasetLinks idl " \
+                "join fetch idl.parent d where i.id = :id"
+        params = omero.sys.ParametersI()
+        params.map['id'] = rlong(img_id)
+        img = gateway.getQueryService().findByQuery(query, params)
+        datasets = []
+        for link in img.iterateDatasetLinks():
+            datasets.append(link.parent)
+        return datasets
+
+
+    @gateway_required
+    def impo(self, args):
+        """Implements the impo(rt) command"""
+        filename = args.channels
+        filename = filename.replace(".yml", "")
+        ds_name = filename.split(args.sep)[0]
+        img_name = filename.split(args.sep)[1]
+
+        set_args = args
+        if args.dataset:
+            ds_query = "select d from Dataset d where d.name = :name"
+            params = omero.sys.ParametersI()
+            params.map['name'] = rstring(ds_name)
+            datasets = self.gateway.getQueryService().findAllByQuery(ds_query, params)
+            if not datasets:
+                self.ctx.err(f"No dataset with name {ds_name} found.")
+                return
+            elif len(datasets) > 1:
+                self.ctx.dbg("More than one dataset found, using latest one")
+                target_ds = max(datasets, key=lambda ds: ds.getId().getValue())
+            else:
+                target_ds = datasets[0]
+            set_args.object = target_ds
+            self.set(set_args)
+        else:
+            img_query = "select c from DatasetImageLink l " \
+                        "join l.child as c " \
+                        "join l.parent as p " \
+                        "where p.name = :name1 and c.name = :name2"
+            params = omero.sys.ParametersI()
+            params.map['name1'] = rstring(ds_name)
+            params.map['name2'] = rstring(img_name)
+            images = self.gateway.getQueryService().findAllByQuery(img_query, params)
+            if not images:
+                self.ctx.err(f"No image with name {img_name} found within a dataset {ds_name}.")
+                return
+            elif len(images) > 1:
+                self.ctx.dbg("More than one images found, using latest one.")
+                target_img = max(images, key=lambda img: img.getId().getValue())
+            else:
+                target_img = images[0]
+            set_args.object = target_img
+            self.set(set_args)
+
+
+    def __do_export(self, ds, img, sep):
+        """
+        Exports the rendering settings of an image to a file
+        called <IMAGE_NAME><SEPARATOR><DATASET_NAME>.yml
+        :param ds: The dataset
+        :param img: The image
+        :param sep: The separator
+        :return: None
+        """
+        try:
+            ro = RenderObject(img)
+            name = f"{ds.getName()}{sep}{img.getName()}.yml"
+            with open(name, "w") as out:
+                out.write(yaml.dump(ro.to_dict(),
+                                    explicit_start=True,
+                                    width=80, indent=4,
+                                    default_flow_style=False).rstrip())
+        except Exception as e:
+            self.ctx.err('ERROR: %s' % e)
+        finally:
+            img._closeRE()
+
+
+    @gateway_required
+    def export(self, args):
+        """Implements the export command"""
+        if isinstance(args.object, Project):
+            prj = self._lookup(self.gateway, "Project", args.object.id)
+            for ds in prj.listChildren():
+                ds = self._lookup(self.gateway, "Dataset", ds.id)
+                for img in ds.listChildren():
+                    self.__do_export(ds, img, args.sep)
+                    if not args.traverse:
+                        break
+
+        elif isinstance(args.object, Dataset):
+            ds = self._lookup(self.gateway, "Dataset", args.object.id)
+            for img in ds.listChildren():
+                self.__do_export(ds, img, args.sep)
+                if not args.traverse:
+                    break
+
+        elif isinstance(args.object, Image):
+            img = self._lookup(self.gateway, "Image", args.object.id)
+            ds = self._get_datasets_for_image(self.gateway, args.object.id.getValue())
+            if len(ds) > 1:
+                self.ctx.out("Warning, more than one dataset found, using latest one")
+                res = max(ds, key=lambda d: d.getId().getValue())
+            else:
+                res = ds[0]
+            res = DatasetWrapper(conn=self.gateway, obj=res)
+            self.__do_export(res, img, args.sep)
+
+        else:
+            self.ctx.err(f"{args.object.__class__.__name__} not supported yet ")
+
 
     @gateway_required
     def copy(self, args):

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -22,6 +22,7 @@ import sys
 import time
 import json
 import yaml
+import omero
 
 from functools import wraps
 


### PR DESCRIPTION
I just need a better way to export rendering settings from a pilot and import them again on IDR prod, the approach via Ids doesn't work, because they are obviously different on the machines. This PR adds an `export` and `impo`(rt) command, which exports rendering settings as yml files (<dataset name><separator><image name>.yml) resp. imports them again. This can be done either one per dataset, or traverse datasets and export one renderings settings yml for each image.

It only works for Project/Dataset/Image for now, not for Screen/Plate/Well, yet. I'll just open that as draft PR, if anyone else want to use it, install it from my branch. Assume it won't be merged anyway.

