### PR TITLE
Remove python-future dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,8 @@ setup(
     install_requires=[
         'PyYAML',
         'omero-py>=5.6.0',
-        'future'
         ],
-    python_requires='>=3',
+    python_requires='>=3.8',
     url='%s' % url,
     zip_safe=False,
     download_url='%s/v%s.tar.gz' % (url, version),

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -18,11 +18,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import print_function
-from past.builtins import long
-from builtins import str
-from builtins import range
-from builtins import object
 import sys
 import time
 import json
@@ -783,7 +778,7 @@ class RenderControl(BaseControl):
         pixid = img.getPrimaryPixels().id
 
         try:
-            rps.setPixelsId(long(pixid), False, fail)
+            rps.setPixelsId(int(pixid), False, fail)
             msg = "ok:"
         except Exception as e:
             error = e
@@ -793,7 +788,7 @@ class RenderControl(BaseControl):
             rps.close()
         else:
             try:
-                rps.setPixelsId(long(pixid), False, make)
+                rps.setPixelsId(int(pixid), False, make)
                 msg = "fill:"
             except KeyboardInterrupt:
                 msg = "cancel:"

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -19,10 +19,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import division
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import json
 import pytest
 
@@ -205,7 +201,7 @@ class TestRender(CLITest):
                 assert img.getDefaultZ() == rdef.get('z') - 1
             else:
                 # If not set, default Z plane is the middle one
-                assert img.getDefaultZ() == (int)(old_div(img.getSizeZ(), 2))
+                assert img.getDefaultZ() == (int)(img.getSizeZ() // 2)
 
     def assert_channel_rdef(self, channel, rdef, version=2):
         assert channel.getLabel() == rdef['label']


### PR DESCRIPTION
See https://github.com/ome/omero-py/pull/390 for the corresponding upstream changes

Replace all future/past as well as builtins imports
This should allow to install and use the render plugin on Python 3.12 environments. The CI tests (Rocky Linux 9 / Python 3.9) should remain green