### PR TITLE
Fix thumbnail generation with missing rendering definition

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -807,12 +807,14 @@ class RenderControl(BaseControl):
         if error:
             error = str(error).split("\n")[0]
         elif thumb:
+            ctx = {'omero.group': str(img.details.group.id.val)}
             tb = client.sf.createThumbnailStore()
             try:
                 has_rendering_settings = tb.setPixelsId(int(pixid), ctx)
                 if not has_rendering_settings:
                     try:
                         tb.resetDefaults(ctx)
+                        tb.setPixelsId(int(pixid), ctx)
                         tb.getThumbnailByLongestSide(rint(96), ctx)
                     except Exception as e:
                         msg = "fail:"

--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -809,8 +809,16 @@ class RenderControl(BaseControl):
         elif thumb:
             tb = client.sf.createThumbnailStore()
             try:
-                tb.setPixelsId(int(pixid), ctx)
-                tb.getThumbnailByLongestSide(rint(96), ctx)
+                has_rendering_settings = tb.setPixelsId(int(pixid), ctx)
+                if not has_rendering_settings:
+                    try:
+                        tb.resetDefaults(ctx)
+                        tb.getThumbnailByLongestSide(rint(96), ctx)
+                    except Exception as e:
+                        msg = "fail:"
+                        error = e
+                else:
+                    tb.getThumbnailByLongestSide(rint(96), ctx)
             finally:
                 tb.close()
 

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -28,6 +28,7 @@ import pytest
 
 from omero_cli_render import RenderControl
 from omero.cli import NonZeroReturnCode
+from omero.plugins.delete import DeleteControl
 from cli import CLITest
 from omero.gateway import BlitzGateway
 import os.path
@@ -43,6 +44,8 @@ class TestRender(CLITest):
     def setup_method(self, method):
         super(TestRender, self).setup_method(method)
         self.cli.register("render", RenderControl, "TEST")
+        self.cli.register("delete", DeleteControl, "TEST")
+        self.delete_args = self.args + ["delete"]
         self.args += ["render"]
         self.idonly = "-1"
         self.imageid = "Image:-1"
@@ -416,3 +419,12 @@ class TestRender(CLITest):
         self.args += ["set", self.idonly, str(rdfile)]
         self.cli.invoke(self.args, strict=True)
         self.assert_target_rdef(self.idonly, rd)
+
+    def test_thumb_nordef(self):
+        self.create_image()
+        self.delete_args += [
+            "Image/Thumbnail:" + self.idonly,
+            "Image/RenderingDef:" + self.idonly]
+        self.cli.invoke(self.delete_args, strict=True)
+        self.args += ["test", "--thumb", self.idonly]
+        self.cli.invoke(self.args, strict=True)

--- a/test/integration/clitest/test_render.py
+++ b/test/integration/clitest/test_render.py
@@ -420,7 +420,8 @@ class TestRender(CLITest):
         self.cli.invoke(self.args, strict=True)
         self.assert_target_rdef(self.idonly, rd)
 
-    def test_thumb_nordef(self):
+    def test_thumb_no_renderingdef(self):
+        """Test thumbnail generation when the Image has no RenderingDef"""
         self.create_image()
         self.delete_args += [
             "Image/Thumbnail:" + self.idonly,


### PR DESCRIPTION
This PR aims to fix the scenario where an user runs `omero render test --thumb` on an OMERO Image with no associated `RenderingDef` and `Thumbnail` object. With the current version of the CLI render plugin, the server should throw an exception similar to:

```
    serverStackTrace = ome.conditions.SecurityViolation: isGraphCriticalCheck: not enough context
        at ome.security.basic.CurrentDetails.isGraphCritical(CurrentDetails.java:220)
        at ome.security.basic.BasicSecuritySystem.isGraphCritical(BasicSecuritySystem.java:352)
        at ome.services.ThumbnailCtx.isExtendedGraphCritical(ThumbnailCtx.java:728)
        at ome.services.ThumbnailBean.errorIfNullRenderingDef(ThumbnailBean.java:768)
        at ome.services.ThumbnailBean.errorIfNullPixelsAndRenderingDef(ThumbnailBean.java:748)
        at ome.services.ThumbnailBean.getThumbnailByLongestSide(ThumbnailBean.java:1308)
        ....
```

With this PR, the code should check the return value of `tb.setPixelsId` and handle the case where it is `false` (no rendering settings) by calling `tb.resetDefaults` and the command should complete successfully generating a new rendering definition and thumbnail.

The integration test added to this PR should provide an example of how to reproduce the original issue i.e. import an original image and run `omero delete Image/RenderingDef:<id> Image/Thumbnail:<id>` to delete the associated objects.

A more real-world workflow where this scenario will arise is the `chown` workflow. As per the current server rules, unless the data is in a private group, changing ownership of images will _not_ change the ownership of the `RenderingDef` and `Thumbnail` object in the graph, leaving these associated with the original owner. This logic has some implications for OMERO.web in particular when changing the ownership of all images in a dataset or screen as the center pane loading will attempt to generate new rendering def and thumbnail objects for the new owner of the images. Depending on the configuration and size of the dataset, this can lead to time-outs leaving the data in a stale situation. 

The proposed changes should allow to run `omero  render test --thumb {Dataset/Project/Plate}:<id>` and regenerate these thumbnails as a follow-up of the chown, hopefully leading to a much better user experience within the constraints of the current graph implementations.

/cc @mabruce @jburel @erindiel 

