### PR TITLE
gateway_required() uses omero_user_token if no username and password

### DIFF
--- a/src/omero_cli_render.py
+++ b/src/omero_cli_render.py
@@ -350,6 +350,26 @@ def gateway_required(func):
     """
     @wraps(func)
     def _wrapper(self, *args, **kwargs):
+        cliargs = args[0]
+        if cliargs.user is None and cliargs.password is None:
+            # try to get token from omero_user_token
+            try:
+                from omero_user_token import getter
+                token = getter()
+                key, hostport = token.split('@')
+                host, port = hostport.split(':')
+                cliargs.key = key
+                if cliargs.server:
+                    assert cliargs.server == host
+                else:
+                    cliargs.server = host
+                if cliargs.port:
+                    assert cliargs.port == port
+                else:
+                    cliargs.port == port
+            except ImportError:
+                pass
+
         self.client = self.ctx.conn(*args)
         self.gateway = BlitzGateway(client_obj=self.client)
 


### PR DESCRIPTION
This is an experimental approach to fix https://github.com/IDR/deployment/issues/426.

Usage:
 - We create a user token
 - This token can be used by omero-cli-render to login for commands that use `gateway_required`

```
omero_user_token set -u myusername
omero render test Image:853
 ```

Actually, I have to say I don't really understand the session management going on here!

Without this PR it's already possible to do:
```
omero login
omero render test Image:853
```
Or even:
```
# asked to login...
omero render test Image:853

# on repeat, uses existing session
omero render test Image:853
```

The only difference here from using `omero_user_token` above is the timeout. `Idle timeout: 1440 min` is default for `omero_user_token` whereas it's otherwise `Idle timeout: 10 min`.

cc @sbesson 